### PR TITLE
docs: edit spec document and comments for clarity

### DIFF
--- a/crates/mitex-spec/src/lib.rs
+++ b/crates/mitex-spec/src/lib.rs
@@ -1,7 +1,7 @@
 //! Specification structure of a set of LaTeX commands.
 //!
-//! The specification will be passed to #mitex for converting LaTeX code
-//! correctly. For example, #mitex Parser uses it to produce an AST that respect
+//! The specification will be passed to MiTeX for converting LaTeX code
+//! correctly. For example, MiTeX Parser uses it to produce an AST that respect
 //! the shape of commands.
 //!
 //! Note: since we need to process environments statically, users cannot

--- a/crates/mitex-spec/src/lib.rs
+++ b/crates/mitex-spec/src/lib.rs
@@ -1,13 +1,13 @@
-//! Specification structure of a set of LaTeX commands
+//! Specification structure of a set of LaTeX commands.
 //!
-//! The specification object will be passed to MiTeX Parser and MiTeX Converter.
-//! It is used by the parser to produce ASTs which respects shape of commands.
-//! It is used by the converter to convert ASTs into a valid typst code.
+//! The specification will be passed to #mitex for converting LaTeX code
+//! correctly. For example, #mitex Parser uses it to produce an AST that respect
+//! the shape of commands.
 //!
-//! Note: since we need process environments statically, users cannot override
-//! `\begin`, `\end`, `\left`, and `\right` command.
+//! Note: since we need to process environments statically, users cannot
+//! override the `\begin` and `\end` commands.
 //!
-//! See <https://github.com/OrangeX4/mitex/blob/main/docs/spec.typ> for detailed description.
+//! See <https://github.com/mitex-rs/mitex/blob/main/docs/spec.typ> for detailed description.
 
 use std::sync::Arc;
 
@@ -19,8 +19,13 @@ pub mod query;
 mod stream;
 pub use query::CommandSpecRepr as JsonCommandSpec;
 
-/// An item of command specification.
-/// It is either a command or an environment.
+/// An item of command specification. It is either a normal _command_ or an
+/// _environment_.
+/// See [Command Syntax] for concept of _command_.
+/// See [Environment Syntax] for concept of _environment_.
+///
+/// [Command Syntax]: https://latexref.xyz/LaTeX-command-syntax.html
+/// [Environment Syntax]: https://latexref.xyz/Environment-syntax.html
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "rkyv", derive(Archive, rDeser, rSer))]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
@@ -29,8 +34,7 @@ pub enum CommandSpecItem {
     Env(EnvShape),
 }
 
-/// Command specification contains a set of commands
-/// and environments.
+/// Command specification that contains a set of commands and environments.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "rkyv", derive(Archive, rDeser, rSer))]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
@@ -81,12 +85,12 @@ impl CommandSpec {
         Self(Arc::new(CommandSpecRepr { commands }))
     }
 
-    /// Get the command specification
+    /// Get an item by name
     pub fn get(&self, name: &str) -> Option<&CommandSpecItem> {
         self.0.commands.get(name)
     }
 
-    /// Get the command specification in kind of command
+    /// Get an item by name in kind of _command_
     pub fn get_cmd(&self, name: &str) -> Option<&CmdShape> {
         self.get(name).and_then(|item| {
             if let CommandSpecItem::Cmd(item) = item {
@@ -97,7 +101,7 @@ impl CommandSpec {
         })
     }
 
-    /// Get the command specification in kind of environment
+    /// Get an item by name in kind of _environment_
     pub fn get_env(&self, name: &str) -> Option<&EnvShape> {
         self.get(name).and_then(|item| {
             if let CommandSpecItem::Env(item) = item {
@@ -113,10 +117,10 @@ impl CommandSpec {
 #[cfg_attr(feature = "rkyv", derive(Archive, rDeser, rSer))]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct CmdShape {
-    /// Describing how could we matches the arguments of a command item
+    /// Describes how we could match the arguments of a command item.
     pub args: ArgShape,
-    /// Alias command for typst handler
-    /// For exmaple, alias `\prod` to typst's `product`
+    /// Makes the command alias to some Typst handler.
+    /// For exmaple, alias `\prod` to Typst's `product`
     pub alias: Option<String>,
 }
 
@@ -124,15 +128,13 @@ pub struct CmdShape {
 #[cfg_attr(feature = "rkyv", derive(Archive, rDeser, rSer))]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub struct EnvShape {
-    /// Describing how could we matches the arguments of an environment item
+    /// Describes how we could match the arguments of an environment item.
     pub args: ArgPattern,
-    /// Specify how could we process items before passing them
-    /// to the typst handler
+    /// Specifies how we could process items before passing them
+    /// to the Typst handler
     pub ctx_feature: ContextFeature,
-    /// Alias command for typst handler
-    /// For exmaple, alias `pmatrix` to `pmat`
-    /// And specify `let pmat = math.mat.with(delim: "(")`
-    /// in scope
+    /// Makes the command alias to some Typst handler.
+    /// For exmaple, alias `\pmatrix` to a Typst function `pmat` in scope.
     pub alias: Option<String>,
 }
 
@@ -147,63 +149,74 @@ pub mod argument_kind {
     pub const ARGUMENT_KIND_PAREN: char = 'p';
 }
 
-/// An efficient pattern used for matching.
-/// It is essential regex things but one
-/// can specify the pattern by fixed, range,
-/// or greedy length to achieve higher performance.
+/// An efficient pattern used for argument matching.
 ///
-/// Let us show usage of glob pattern by \sqrt, which is `{,b}t`
-/// Exp 1. For `\sqrt{2}{3}`, parser
-///   requires the pattern to match with `tt`,
-///   Here, `{,b}t` matches and
-///   yields string `t` (correspond to `{2}`)
-/// Exp 2. For `\sqrt[1]{2}{2}`, parser
-///   requires the pattern to match with `btt`,
-///   Here, `{,b}t` matches and
-///   yields string `bt` (correspond to `[1]{2}`)
+/// There are four kinds of pattern. The most powerful one is
+/// [`ArgPattern::Glob`], which matches an sequence of input as arguments. Among
+/// these four kinds, [`ArgPattern::Glob`] can already match all possible inputs
+/// in our use cases. But one should specify a fixed length pattern
+/// ([`ArgPattern::FixedLenTerm`]), a range length pattern
+/// ([`ArgPattern::RangeLenTerm`]), or a greedy pattern
+/// ([`ArgPattern::Greedy`]) to achieve better performance.
 ///
-/// Kind of item to match, also see [`argument_kind`]:
+/// Let us look at usage of a glob pattern by \sqrt, which is `{,b}t`.
+///
+/// - Example 1. For `\sqrt{2}{3}`, parser requires the pattern to match with an
+///   encoded string `tt`. Here, `{,b}t` matches and yields the string `t`
+///   (which corresponds to `{2}`).
+///
+/// - Example 2. For `\sqrt[1]{2}{2}`, parser requires the pattern to match with
+///   an encoded string `btt`. Here, `{,b}t` matches and yields the string `bt`
+///   (which corresponds to `[1]{2}`).
+///
+/// Kinds of item to match:
 /// - Bracket/b: []
 /// - Parenthesis/p: ()
-/// - Term/t: any rest of terms, typically {} or single char
+/// - Term/t: any remaining terms, typically {} or a single char
+///
+/// Note: any prefix of the argument pattern are matched during the parse stage,
+/// so you need to check whether it is complete in later stages.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "rkyv", derive(Archive, rDeser, rSer))]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub enum ArgPattern {
-    /// None of arguments is passed, i.e. it is processed as a
-    /// variable in typst.
-    /// Note: this is different from FixedLenTerm(0)
-    /// Where, \alpha is None, but not FixedLenTerm(0)
-    /// E.g. \alpha => $alpha$
+    /// No arguments are passed, i.e. this is processed as a variable in Typst.
+    ///
+    /// E.g. `\alpha` => `$alpha$`, where `\alpha` has an argument pattern of
+    /// `None`
     None,
-    /// Fixed length pattern, equivalent to `/t{x}/g`
-    /// E.g. \hat x y => $hat(x) y$,
-    /// E.g. 1 \sum\limits => $1 limits(sum)$,
+    /// Fixed length pattern, equivalent to repeat `{,t}` for `x` times
+    ///
+    /// E.g. `\hat x y` => `$hat(x) y$`, where `\hat` has an argument pattern of
+    /// `FixedLenTerm(1)`
+    ///
+    /// E.g. `1 \sum\limits` => `$1 limits(sum)$`, where `\limits` has an
+    /// argument pattern of `FixedLenTerm(1)`
     FixedLenTerm(u8),
-    /// Range length pattern (as much as possible),
-    /// equivalent to `/t{x,y}/g`
+    /// Range length pattern (matches as much as possible), equivalent to
+    /// repeat `t` for `x` times, then repeat `{,t}` for `y` times.
+    ///
     /// No example
     RangeLenTerm(u8, u8),
-    /// Receive terms as much as possible,
-    /// equivalent to `/t*/g`
+    /// Receives any items as much as possible, equivalent to `*`.
+    ///
     /// E.g. \over, \displaystyle
     Greedy,
-    /// Most powerful pattern, but slightly slow
-    /// Note that the glob must accept all prefix of the input
+    /// The most powerful pattern, but slightly slow.
+    /// Note that the glob must accept the whole prefix of the input.
     ///
-    /// E.g. \sqrt has a glob pattern of `{,b}t`
-    /// Description:
-    /// - {,b}: first, it matches an bracket option, e.g. `\sqrt[3]`
-    /// - t: it later matches a single term, e.g. `\sqrt[3]{a}` or `\sqrt{a}`
-    /// Note: any prefix of the glob is valid in parse stage hence you need to
-    /// check whether it is complete in later stage.
+    /// E.g. \sqrt has a glob argument pattern of `{,b}t`
+    ///
+    /// Description of the glob pattern:
+    /// - {,b}: first, it matches a bracket option, e.g. `\sqrt[3]`
+    /// - t: it then matches a single term, e.g. `\sqrt[3]{a}` or `\sqrt{a}`
     Glob(Arc<str>),
 }
 
 // struct ArgShape(ArgPattern, Direction);
 
-/// Shape of arguments
-/// With direction to match since
+/// Shape of arguments with direction to match since.
+///
 /// Note: We currently only support
 /// - `Direction::Right` with any `ArgPattern`
 /// - `Direction::Left` with `ArgPattern::FixedLenTerm(1)`
@@ -212,15 +225,19 @@ pub enum ArgPattern {
 #[cfg_attr(feature = "rkyv", derive(Archive, rDeser, rSer))]
 #[cfg_attr(feature = "rkyv-validation", archive(check_bytes))]
 pub enum ArgShape {
-    /// A command that assosicates with right side of items.
-    /// E.g. \hat
+    /// A command that associates with the right side of items.
+    ///
+    /// E.g. `\hat`
     Right(ArgPattern),
-    /// A command that assosicates with left side of items, and with
-    /// `ArgPattern::FixedLenTerm(1)`. E.g. \limits
+    /// A command that associates with the left side of items, and with
+    /// `ArgPattern::FixedLenTerm(1)`.
+    ///
+    /// E.g. `\limits`
     Left1,
-    /// A command that assosicates with both side of items, and with
-    /// `ArgPattern::Greedy`. Also known as infix operators.
-    /// E.g. \over
+    /// A command that associates with both side of items, and with
+    /// `ArgPattern::Greedy`, also known as infix operators.
+    ///
+    /// E.g. `\over`
     InfixGreedy,
 }
 

--- a/crates/mitex-spec/src/query.rs
+++ b/crates/mitex-spec/src/query.rs
@@ -18,9 +18,9 @@ pub struct PackageSpec {
 pub struct PackagesVec(pub Vec<PackageSpec>);
 
 /// An item of command specification.
-/// This contains more sugar than the canonical representation.
+/// This enum contains more sugar than the canonical representation.
 ///
-/// See [`mitex_spec::CommandSpecItem`] for more details.
+/// See [`crate::CommandSpecItem`] for more details.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind")]
 pub enum CommandSpecItem {
@@ -41,20 +41,28 @@ pub enum CommandSpecItem {
     /// A command that takes two arguments.
     #[serde(rename = "cmd2")]
     Command2,
+    /// A command that takes one argument and is a left-associative operator.
     #[serde(rename = "left1-cmd")]
     CmdLeft1,
+    /// A command that takes no argument and is a matrix environment.
     #[serde(rename = "matrix-env")]
     EnvMatrix,
+    /// A command that takes no argument and is a normal environment.
     #[serde(rename = "normal-env")]
     EnvNormal,
 
+    /// A command that is aliased to a Typst symbol.
     #[serde(rename = "alias-sym")]
     SymAlias { alias: String },
+    /// A command that is greedy and is aliased to a Typst handler.
     #[serde(rename = "greedy-cmd")]
     CmdGreedy { alias: String },
     #[serde(rename = "infix-cmd")]
+    /// A command that is an infix operator and is aliased to a Typst handler.
     CmdInfix { alias: String },
     #[serde(rename = "glob-cmd")]
+    /// A command that has a glob argument pattern and is aliased to a Typst
+    /// handler.
     CmdGlob { pattern: String, alias: String },
 }
 
@@ -82,6 +90,8 @@ impl From<CommandSpecItem> for crate::CommandSpecItem {
     }
 }
 
+/// The following defined structs are copied so we don't maintain their
+/// comments. See [`crate::CommandSpecRepr`] for canonical representation.
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct CommandSpecRepr {
     pub commands: HashMap<String, CommandSpecItem>,

--- a/docs/spec.typ
+++ b/docs/spec.typ
@@ -85,13 +85,13 @@ It produces:
   $ alpha x $
 ]
 
-= Specification to LaTeX Commands (for developers)
+= Specification of LaTeX Commands (for developers)
 
-// todo: translate rust code descriptions to natural language
+// todo: translate Rust code descriptions to natural language
 
-Define how one user specifies commands in typst for #mitex. And it is aware of a special case of command, environment, which is in shape of `\begin{e}...\end{e}`.
+Define how a user specifies commands in Typst for #mitex. Mitex is aware of a special case of command, environment, which is in shape of `\begin{e}...\end{e}`.
 
-The specification is structured as following in rust:
+The specification is structured as following in Rust:
 
 ```rs
 pub enum Command {
@@ -104,54 +104,54 @@ pub struct CommandSpec {
 }
 ```
 
-The specification will be passed to #mitex Parser, and used for produce ASTs which respects shape of commands.
+The specification will be passed to the #mitex Parser and used to produce ASTs, which respect the shape of commands.
 
-Note: since we need process environments statically, users cannot override `\begin` and `\end` command.
+Note: since we need to process environments statically, users cannot override the `\begin` and `\end` commands.
 
 ```rust
 pub struct CmdShape {
-    /// Describing how could we matches the arguments of a command item
+    /// Describing how we could match the arguments of a command item
     pub args: ArgShape,
     /// Alias command for typst handler
-    /// For exmaple, alias `\prod` to typst's `product`
+    /// For exmaple, alias `\prod` to Typst's `product`
     pub alias: Option<String>,
 }
 
 pub struct EnvShape {
-    /// Describing how could we matches the arguments of an environment item
+    /// Describing how we could match the arguments of an environment item
     pub args: ArgPattern,
-    /// Specify how could we process items before passing them
-    /// to the typst handler
+    /// Specify how we could process items before passing them
+    /// to the Typst handler
     pub ctx_feature: ContextFeature,
-    /// Alias command for typst handler
+    /// Alias command for Typst handler.
     /// For exmaple, alias `pmatrix` to `pmat`
-    /// And specify `let pmat = math.mat.with(delim: "(")`
-    /// in scope
+    /// and specify `let pmat = math.mat.with(delim: "(")`
+    /// in scope:
     pub alias: Option<String>,
 }
 
 /// An efficient pattern used for matching.
-/// It is essential regex things but one
-/// can specify the pattern by fixed, range,
-/// or greedy length to achieve higher performance.
+/// It is essential to use regex but one
+/// can specify a fixed pattern, a range,
+/// or a greedy length to achieve better performance.
 ///
-/// Let us show usage of glob pattern by \sqrt, which is `{,b}t`
+/// Let us look at usage of a glob pattern by \sqrt, which is `{,b}t`
 /// Exp 1. For `\sqrt{2}{3}`, parser
 ///   requires the pattern to match with `tt`,
 ///   Here, `{,b}t` matches and
-///   yields string `t` (correspond to `{2}`)
+///   yields the string `t` (which corresponds to `{2}`).
 /// Exp 2. For `\sqrt[1]{2}{2}`, parser
 ///   requires the pattern to match with `btt`,
 ///   Here, `{,b}t` matches and
-///   yields string `bt` (correspond to `[1]{2}`)
+///   yields the string `bt` (which corresponds to `[1]{2}`).
 ///
-/// Kind of item to match:
+/// Kinds of item to match:
 /// - Bracket/b: []
 /// - Parenthesis/p: ()
-/// - Term/t: any rest of terms, typically {} or single char
+/// - Term/t: any remaining terms, typically {} or a single char
 pub enum ArgPattern {
-    /// None of arguments is passed, i.e. it is processed as a
-    /// variable in typst.
+    /// No arguments are passed, i.e. this is processed as a
+    /// variable in Typst.
     /// Note: this is different from FixedLenTerm(0)
     /// Where, \alpha is None, but not FixedLenTerm(0)
     /// E.g. \alpha => $alpha$
@@ -168,15 +168,15 @@ pub enum ArgPattern {
     /// equivalent to `/t*/g`
     /// E.g. \over, \displaystyle
     Greedy,
-    /// Most powerful pattern, but slightly slow
-    /// Note that the glob must accept all prefix of the input
+    /// The most powerful pattern, but slightly slow.
+    /// Note that the glob must accept the whole prefix of the input.
     ///
     /// E.g. \sqrt has a glob pattern of `{,b}t`
     /// Description:
-    /// - {,b}: first, it matches an bracket option, e.g. `\sqrt[3]`
-    /// - t: it later matches a single term, e.g. `\sqrt[3]{a}` or `\sqrt{a}`
-    /// Note: any prefix of the glob is valid in parse stage hence you need to
-    /// check whether it is complete in later stage.
+    /// - {,b}: first, it matches a bracket option, e.g. `\sqrt[3]`
+    /// - t: it then matches a single term, e.g. `\sqrt[3]{a}` or `\sqrt{a}`
+    /// Note: any prefix of the glob is valid during the parse stage, so you need to
+    /// check whether it is complete in later stages.
     Glob(Arc<str>),
 }
 
@@ -189,13 +189,13 @@ pub enum ArgPattern {
 /// - `Direction::Left` with `ArgPattern::FixedLenTerm(1)`
 /// - `Direction::Infix` with `ArgPattern::Greedy`
 pub enum ArgShape {
-    /// A command that assosicates with right side of items.
+    /// A command that associates with the right side of items.
     /// E.g. \hat
     Right(ArgPattern),
-    /// A command that assosicates with left side of items, and with `ArgPattern::FixedLenTerm(1)`.
+    /// A command that associates with the left side of items, and with `ArgPattern::FixedLenTerm(1)`.
     /// E.g. \limits
     Left1,
-    /// A command that assosicates with both side of items, and with `ArgPattern::Greedy`.
+    /// A command that associates with both side of items, and with `ArgPattern::Greedy`.
     /// Also known as infix operators.
     /// E.g. \over
     InfixGreedy,
@@ -246,13 +246,13 @@ AttachItem(
   Bottom(Word("x"))
 ),
 Word("f"),
-# used for paren escaping (special case in typst)
+# used for paren escaping (a special case in typst)
 Paren(Word("x")),
 ```
 
 Sample #sample-counter():
 
-Spaces are not omitted. It is useful for processing `\text`.
+Spaces are not omitted. This is useful for processing `\text`.
 
 ```tex
 \frac 1  2 ␠
@@ -271,7 +271,7 @@ Space(" "),
 
 Sample #sample-counter():
 
-Attach items are identified.
+Attached items are identified.
 
 ```tex
 x_1''^2␠
@@ -287,7 +287,7 @@ AttachItem(
 
 Sample #sample-counter():
 
-Attach items are identified (case 2).
+Attached items are identified (case 2).
 
 ```tex
 x''_1␠
@@ -303,7 +303,7 @@ AttachItem(
 
 Sample #sample-counter():
 
-Apostrophes without attach target will become regular text.
+Apostrophes without an attached target will become regular text.
 
 ```tex
 ''␠
@@ -316,7 +316,7 @@ Word("'")
 
 Sample #sample-counter():
 
-Apostrophes that occupy position of command argument will become regular text.
+Apostrophes that in the position of a command argument will become regular text.
 
 ```tex
 \frac''␠


### PR DESCRIPTION
I edited the comment text in spec.typ for clarity.