### PR TITLE
feat(m_engine): support {{,re}new} environment

### DIFF
--- a/crates/mitex-lexer/src/lib.rs
+++ b/crates/mitex-lexer/src/lib.rs
@@ -170,6 +170,15 @@ impl<'a> StreamContext<'a> {
         res
     }
 
+    fn peek_word_opt(&mut self, bk: BraceKind) -> Option<Tok<'a>> {
+        let res = self.peek_full().filter(|res| matches!(res.0, Token::Word));
+        self.next_not_trivia()?;
+
+        self.eat_if(Token::Right(bk));
+
+        res
+    }
+
     fn peek_cmd_name_opt(&mut self, bk: BraceKind) -> Option<Tok<'a>> {
         let res = self
             .peek_full()

--- a/crates/mitex-lexer/tests/expand_macro.rs
+++ b/crates/mitex-lexer/tests/expand_macro.rs
@@ -174,6 +174,11 @@ fn subst_macro() {
     Right(Paren)(")")
     Word("y")
     "###);
+    assert_snapshot!(tokens(r#"\newenvironment{f}[2]{begin}{end}\begin{f}test\end{f}"#), @r###"
+    Word("begin")
+    Word("st")
+    Word("end")
+    "###);
 }
 
 #[test]


### PR DESCRIPTION
These commands are supported
- \newenvironment
- \newenvironment*
- \renewenvironment
- \renewenvironment*