### PR TITLE
feat(m_engine): support if{false,true,typst} conditional macros

### DIFF
--- a/crates/mitex-lexer/src/lib.rs
+++ b/crates/mitex-lexer/src/lib.rs
@@ -512,6 +512,7 @@ fn lex_command_name(lexer: &mut logos::Lexer<Token>) -> CommandName {
         "ifdim" => CommandName::If(IfDim),
         "ifeof" => CommandName::If(IfEof),
         "@ifstar" => CommandName::If(IfStar),
+        "else" => CommandName::Else,
         "fi" => CommandName::EndIf,
         "left" => CommandName::Left,
         "right" => CommandName::Right,
@@ -701,6 +702,8 @@ pub enum CommandName {
     ErrorEndEnvironment,
     /// clause of BlockComment: \iffalse
     If(IfCommandName),
+    /// clause of BlockComment: \else
+    Else,
     /// clause of BlockComment: \fi
     EndIf,
     /// clause of LRItem: \left

--- a/crates/mitex-lexer/src/lib.rs
+++ b/crates/mitex-lexer/src/lib.rs
@@ -700,11 +700,11 @@ pub enum CommandName {
     ErrorBeginEnvironment,
     /// clause of Environment: \end, but error
     ErrorEndEnvironment,
-    /// clause of BlockComment: \iffalse
+    /// clause of IfStatements: \if...
     If(IfCommandName),
-    /// clause of BlockComment: \else
+    /// clause of IfStatements: \else
     Else,
-    /// clause of BlockComment: \fi
+    /// clause of IfStatements: \fi
     EndIf,
     /// clause of LRItem: \left
     Left,

--- a/crates/mitex-lexer/src/lib.rs
+++ b/crates/mitex-lexer/src/lib.rs
@@ -462,6 +462,7 @@ const LEN_ASCII: usize = 1;
 // todo: handle commands with underscores, whcih would require command names
 // todo: from specification
 fn lex_command_name(lexer: &mut logos::Lexer<Token>) -> CommandName {
+    use IfCommandName::*;
     let command_start = &lexer.source()[lexer.span().end..];
 
     // Get the first char in utf8 case
@@ -493,8 +494,25 @@ fn lex_command_name(lexer: &mut logos::Lexer<Token>) -> CommandName {
 
     let name = &command_start[..LEN_ASCII + bump_size];
     match name {
-        "iffalse" => CommandName::BeginBlockComment,
-        "fi" => CommandName::EndBlockComment,
+        "if" => CommandName::If(If),
+        "iftypst" => CommandName::If(IfTypst),
+        "iffalse" => CommandName::If(IfFalse),
+        "iftrue" => CommandName::If(IfTrue),
+        "ifcase" => CommandName::If(IfCase),
+        "ifnum" => CommandName::If(IfNum),
+        "ifcat" => CommandName::If(IfCat),
+        "ifx" => CommandName::If(IfX),
+        "ifvoid" => CommandName::If(IfVoid),
+        "ifhbox" => CommandName::If(IfHBox),
+        "ifvbox" => CommandName::If(IfVBox),
+        "ifhmode" => CommandName::If(IfHMode),
+        "ifmmode" => CommandName::If(IfMMode),
+        "ifvmode" => CommandName::If(IfVMode),
+        "ifinner" => CommandName::If(IfInner),
+        "ifdim" => CommandName::If(IfDim),
+        "ifeof" => CommandName::If(IfEof),
+        "@ifstar" => CommandName::If(IfStar),
+        "fi" => CommandName::EndIf,
         "left" => CommandName::Left,
         "right" => CommandName::Right,
         "begin" => lex_begin_end(lexer, true),
@@ -629,6 +647,47 @@ fn lex_begin_end(lexer: &mut logos::Lexer<Token>, is_begin: bool) -> CommandName
 
 /// The command name used by parser
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub enum IfCommandName {
+    /// \if
+    If,
+    /// \iftypst
+    IfTypst,
+    /// \iffalse
+    IfFalse,
+    /// \iftrue
+    IfTrue,
+    /// \ifcase
+    IfCase,
+    /// \ifnum
+    IfNum,
+    /// \ifcat
+    IfCat,
+    /// \ifx
+    IfX,
+    /// \ifvoid
+    IfVoid,
+    /// \ifhbox
+    IfHBox,
+    /// \ifvbox
+    IfVBox,
+    /// \ifhmode
+    IfHMode,
+    /// \ifmmode
+    IfMMode,
+    /// \ifvmode
+    IfVMode,
+    /// \ifinner
+    IfInner,
+    /// \ifdim
+    IfDim,
+    /// \ifeof
+    IfEof,
+    /// \@ifstar
+    IfStar,
+}
+
+/// The command name used by parser
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
 pub enum CommandName {
     /// Rest of the command names
     Generic,
@@ -641,9 +700,9 @@ pub enum CommandName {
     /// clause of Environment: \end, but error
     ErrorEndEnvironment,
     /// clause of BlockComment: \iffalse
-    BeginBlockComment,
+    If(IfCommandName),
     /// clause of BlockComment: \fi
-    EndBlockComment,
+    EndIf,
     /// clause of LRItem: \left
     Left,
     /// clause of LRItem: \right

--- a/crates/mitex-lexer/src/macro_engine.rs
+++ b/crates/mitex-lexer/src/macro_engine.rs
@@ -32,12 +32,11 @@
 //!
 //! - \@ifstar
 //! - if
-//! - ifdim
 //! - iffalse
+//! - iftypst
 //! - ifnum
 //! - ifodd
 //! - iftrue
-//! - ifx (restricted)
 //!
 //! - \DeclareOption
 //! - \DeclareOption*
@@ -47,7 +46,6 @@
 //! - \RequirePackage (only regards options)
 //! - \RequirePackageWithOptions (only regards options)
 //! - \documentclass (only regards options)
-//! - \PassOptionsToClass
 //! - \PassOptionsToPackage
 //!
 //! - \IfFileExists
@@ -60,15 +58,19 @@
 //! - \def
 //! - \gdef needs: globals: MacroMap<'a>,
 //!
-//! These commands will be definitely dropped or raise an error (since we are
-//! not a tex engine)
+//! - ifdim
+//! - ifx
 //! - ifvoid
-//! - ifinner
 //! - ifhbox
 //! - ifvbox
+//!
+//! These commands may dropped or raise an error
+//! - ifinner
 //! - ifhmode
 //! - ifmmode
 //! - ifvmode
+//!
+//! These commands will be definitely dropped or raise an error
 //!
 //! - CheckCommand
 //! - CheckCommand*
@@ -79,8 +81,8 @@
 //! - \newsavebox, See 14 Boxes
 //! - \newtheorem
 //! - \newfont
-//!
-//! - class commands, e.g. \ProvidesClass, \LoadClass, \LoadClassWithOptions
+//! - class commands, e.g. \ProvidesClass, \LoadClass, \PassOptionsToClass,
+//!   \LoadClassWithOptions
 
 use std::{
     borrow::Cow,

--- a/crates/mitex-lexer/src/macro_engine.rs
+++ b/crates/mitex-lexer/src/macro_engine.rs
@@ -404,13 +404,15 @@ impl<'a> MacroEngine<'a> {
             };
 
             match token.0 {
-                // a begin environment token traps stream into a macro checking
+                // check a \if... macro
                 Token::CommandName(CommandName::If(i)) => {
                     self.trapped_by_if(ctx, token, i);
                 }
+                // check a \else macro
                 Token::CommandName(CommandName::Else) => {
                     self.trapped_by_else(ctx, token);
                 }
+                // check a \fi macro
                 Token::CommandName(CommandName::EndIf) => {
                     self.trapped_by_endif(ctx, token);
                 }
@@ -445,6 +447,7 @@ impl<'a> MacroEngine<'a> {
         ctx.peek_outer.peeked = ctx.peek_outer.buf.pop();
     }
 
+    /// Skip tokens until a balanced \fi
     fn skip_false_tokens(&mut self, ctx: &mut StreamContext<'a>) {
         let mut nested = 0;
         while let Some(kind) = ctx.peek() {
@@ -467,6 +470,7 @@ impl<'a> MacroEngine<'a> {
         }
     }
 
+    /// \if...
     #[inline]
     fn trapped_by_if(&mut self, ctx: &mut StreamContext<'a>, token: Tok<'a>, i: IfCommandName) {
         ctx.next_token();
@@ -489,6 +493,8 @@ impl<'a> MacroEngine<'a> {
         }
     }
 
+    /// \else
+    #[inline]
     fn trapped_by_else(&mut self, ctx: &mut StreamContext<'a>, token: Tok<'a>) {
         ctx.next_token();
         let last_if = self.reading_if.last().cloned().unwrap_or(None);
@@ -523,6 +529,8 @@ impl<'a> MacroEngine<'a> {
         }
     }
 
+    /// \fi
+    #[inline]
     fn trapped_by_endif(&mut self, ctx: &mut StreamContext<'a>, token: Tok<'a>) {
         ctx.next_token();
         let last_if = self.reading_if.pop().unwrap_or(None);

--- a/crates/mitex-lexer/src/macro_engine.rs
+++ b/crates/mitex-lexer/src/macro_engine.rs
@@ -14,10 +14,15 @@
 //! - \DeclareRobustCommand*
 //! - \providecommand
 //! - \providecommand*
+//!
 //! - \newenvironment
 //! - \newenvironment*
 //! - \renewenvironment
 //! - \renewenvironment*
+//!
+//! - iftypst
+//! - iffalse
+//! - iftrue
 //!
 //! Commands in plan
 //!
@@ -32,11 +37,8 @@
 //!
 //! - \@ifstar
 //! - if
-//! - iffalse
-//! - iftypst
 //! - ifnum
 //! - ifodd
-//! - iftrue
 //!
 //! - \DeclareOption
 //! - \DeclareOption*

--- a/crates/mitex-lexer/src/macro_engine.rs
+++ b/crates/mitex-lexer/src/macro_engine.rs
@@ -92,7 +92,8 @@ use std::{
 
 use crate::{
     snapshot_map::{self, SnapshotMap},
-    BraceKind, BumpTokenStream, CommandName, MacroifyStream, StreamContext, Tok, Token,
+    BraceKind, BumpTokenStream, CommandName, IfCommandName, MacroifyStream, StreamContext, Tok,
+    Token,
 };
 use mitex_spec::CommandSpec;
 
@@ -328,6 +329,15 @@ enum UpdateAction {
     Provide,
 }
 
+#[derive(Clone, Copy, PartialEq)]
+enum IfState {
+    LitFalse,
+    TypstTrue,
+    TypstFalse,
+    False,
+    True,
+}
+
 /// MacroEngine has exact same interface as Lexer, but it expands macros.
 ///
 /// When it meets a macro in token stream, It evaluates a macro into expanded
@@ -341,6 +351,11 @@ pub struct MacroEngine<'a> {
     env_stack: Vec<EnvMacro<'a>>,
     /// Macro stack
     pub reading_macro: Vec<MacroNode<'a>>,
+    /// If stack
+    /// If the value is None, it means the if is not evaluated yet
+    /// If the value is Some(true), it means the if is evaluated to true
+    /// If the value is Some(false), it means the if is evaluated to false
+    reading_if: Vec<Option<IfState>>,
     /// Toekns used by macro stack
     pub scanned_tokens: Vec<Tok<'a>>,
 }
@@ -365,6 +380,7 @@ impl<'a> MacroEngine<'a> {
             macros: std::borrow::Cow::Borrowed(DEFAULT_MACROS.deref()),
             env_stack: Vec::new(),
             reading_macro: Vec::new(),
+            reading_if: Vec::new(),
             scanned_tokens: Vec::new(),
         }
     }
@@ -386,6 +402,16 @@ impl<'a> MacroEngine<'a> {
             };
 
             match token.0 {
+                // a begin environment token traps stream into a macro checking
+                Token::CommandName(CommandName::If(i)) => {
+                    self.trapped_by_if(ctx, token, i);
+                }
+                Token::CommandName(CommandName::Else) => {
+                    self.trapped_by_else(ctx, token);
+                }
+                Token::CommandName(CommandName::EndIf) => {
+                    self.trapped_by_endif(ctx, token);
+                }
                 // a generic command token traps stream into a macro checking
                 //
                 // If it is a real macro, it will be expanded into tokens so parser is unaware of
@@ -415,6 +441,95 @@ impl<'a> MacroEngine<'a> {
 
         // Pop the first token again
         ctx.peek_outer.peeked = ctx.peek_outer.buf.pop();
+    }
+
+    fn skip_false_tokens(&mut self, ctx: &mut StreamContext<'a>) {
+        let mut nested = 0;
+        while let Some(kind) = ctx.peek() {
+            match kind {
+                Token::CommandName(CommandName::If(..)) => {
+                    ctx.next_token();
+                    nested += 1;
+                }
+                Token::CommandName(CommandName::Else) | Token::CommandName(CommandName::EndIf) => {
+                    if nested == 0 {
+                        break;
+                    }
+                    ctx.next_token();
+                    nested -= 1;
+                }
+                _ => {
+                    ctx.next_token();
+                }
+            }
+        }
+    }
+
+    #[inline]
+    fn trapped_by_if(&mut self, ctx: &mut StreamContext<'a>, token: Tok<'a>, i: IfCommandName) {
+        ctx.next_token();
+        match i {
+            IfCommandName::IfFalse => {
+                ctx.push_outer(token);
+                self.reading_if.push(Some(IfState::LitFalse));
+            }
+            IfCommandName::IfTrue => {
+                self.reading_if.push(Some(IfState::True));
+            }
+            IfCommandName::IfTypst => {
+                ctx.push_outer(token);
+                self.reading_if.push(Some(IfState::TypstTrue));
+            }
+            _ => {
+                ctx.push_outer(token);
+                self.reading_if.push(None);
+            }
+        }
+    }
+
+    fn trapped_by_else(&mut self, ctx: &mut StreamContext<'a>, token: Tok<'a>) {
+        ctx.next_token();
+        let last_if = self.reading_if.last().cloned().unwrap_or(None);
+        match last_if {
+            Some(IfState::TypstTrue) => {
+                self.reading_if
+                    .last_mut()
+                    .unwrap()
+                    .replace(IfState::TypstFalse);
+                self.skip_false_tokens(ctx);
+            }
+            Some(IfState::True) => {
+                self.reading_if.last_mut().unwrap().replace(IfState::False);
+                self.skip_false_tokens(ctx);
+            }
+            Some(IfState::False) => {
+                self.reading_if.last_mut().unwrap().replace(IfState::True);
+            }
+            Some(IfState::TypstFalse) => {
+                self.reading_if
+                    .last_mut()
+                    .unwrap()
+                    .replace(IfState::TypstTrue);
+            }
+            Some(IfState::LitFalse) => {
+                self.reading_if.last_mut().unwrap().replace(IfState::True);
+                ctx.push_outer((Token::CommandName(CommandName::EndIf), "\\fi"));
+            }
+            None => {
+                ctx.push_outer(token);
+            }
+        }
+    }
+
+    fn trapped_by_endif(&mut self, ctx: &mut StreamContext<'a>, token: Tok<'a>) {
+        ctx.next_token();
+        let last_if = self.reading_if.pop().unwrap_or(None);
+        match last_if {
+            Some(IfState::True | IfState::False) => {}
+            Some(IfState::TypstFalse | IfState::TypstTrue | IfState::LitFalse) | None => {
+                ctx.push_outer(token);
+            }
+        }
     }
 
     #[inline]

--- a/crates/mitex-lexer/tests/expand_macro.rs
+++ b/crates/mitex-lexer/tests/expand_macro.rs
@@ -233,6 +233,51 @@ fn subst_if() {
     Whitespace(" ")
     Word("x")
     "###);
+    // Description: nested ifs are evaluated
+    assert_snapshot!(tokens(r#"\iftrue\alpha x \iftrue\alpha x2\fi\fi"#), @r###"
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    Whitespace(" ")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x2")
+    "###);
+    assert_snapshot!(tokens(r#"\iftrue\alpha x \iffalse\alpha x2\fi\fi"#), @r###"
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    Whitespace(" ")
+    CommandName(If(IfFalse))("\\iffalse")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x2")
+    CommandName(EndIf)("\\fi")
+    "###);
+    assert_snapshot!(tokens(r#"\iffalse\alpha x \iftrue\alpha x2\fi\fi"#), @r###"
+    CommandName(If(IfFalse))("\\iffalse")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    Whitespace(" ")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x2")
+    CommandName(EndIf)("\\fi")
+    "###);
+    assert_snapshot!(tokens(r#"\iffalse\alpha x \ifhbox\alpha x2\fi\fi"#), @r###"
+    CommandName(If(IfFalse))("\\iffalse")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    Whitespace(" ")
+    CommandName(If(IfHBox))("\\ifhbox")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x2")
+    CommandName(EndIf)("\\fi")
+    CommandName(EndIf)("\\fi")
+    "###);
     // Description: iffalse else escape block comment
     assert_snapshot!(tokens(r#"\iffalse Block Comment\else \alpha x\fi"#), @r###"
     CommandName(If(IfFalse))("\\iffalse")

--- a/crates/mitex-lexer/tests/expand_macro.rs
+++ b/crates/mitex-lexer/tests/expand_macro.rs
@@ -182,6 +182,90 @@ fn subst_macro() {
 }
 
 #[test]
+fn subst_if() {
+    // Description: for block comment
+    assert_snapshot!(tokens(r#"\iffalse Block Comment\fi"#), @r###"
+    CommandName(If(IfFalse))("\\iffalse")
+    Whitespace(" ")
+    Word("Block")
+    Whitespace(" ")
+    Word("Comment")
+    CommandName(EndIf)("\\fi")
+    "###);
+    // Description: iftypst is not evaluated
+    assert_snapshot!(tokens(r#"\iftypst\alpha x\fi"#), @r###"
+    CommandName(If(IfTypst))("\\iftypst")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    CommandName(EndIf)("\\fi")
+    "###);
+    // Description: iftypst else is evaluated
+    assert_snapshot!(tokens(r#"\iftypst\alpha x\else\LaTeX code\fi"#), @r###"
+    CommandName(If(IfTypst))("\\iftypst")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    CommandName(EndIf)("\\fi")
+    "###);
+    // Description: iftypst else is evaluated
+    assert_snapshot!(tokens(r#"\iftypst\alpha x\else\LaTeX code\else\alpha x2\fi"#), @r###"
+    CommandName(If(IfTypst))("\\iftypst")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x2")
+    CommandName(EndIf)("\\fi")
+    "###);
+    // Description: ifhbox is not evaluated
+    assert_snapshot!(tokens(r#"\ifhbox\alpha x\fi"#), @r###"
+    CommandName(If(IfHBox))("\\ifhbox")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    CommandName(EndIf)("\\fi")
+    "###);
+    // Description: iftrue is evaluated
+    assert_snapshot!(tokens(r#"\iftrue\alpha x\fi"#), @r###"
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    "###);
+    // Description: iffalse else escape block comment
+    assert_snapshot!(tokens(r#"\iffalse Block Comment\else \alpha x\fi"#), @r###"
+    CommandName(If(IfFalse))("\\iffalse")
+    Whitespace(" ")
+    Word("Block")
+    Whitespace(" ")
+    Word("Comment")
+    CommandName(EndIf)("\\fi")
+    Whitespace(" ")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    "###);
+    // Description: iffalse else escape block comment
+    assert_snapshot!(tokens(r#"\iffalse Block Comment\else \alpha x\else Ignored\else Show Me\fi"#), @r###"
+    CommandName(If(IfFalse))("\\iffalse")
+    Whitespace(" ")
+    Word("Block")
+    Whitespace(" ")
+    Word("Comment")
+    CommandName(EndIf)("\\fi")
+    Whitespace(" ")
+    CommandName(Generic)("\\alpha")
+    Whitespace(" ")
+    Word("x")
+    Whitespace(" ")
+    Word("Show")
+    Whitespace(" ")
+    Word("Me")
+    "###);
+}
+
+#[test]
 fn newcommand_recursive() {
     assert_snapshot!(tokens(r#"\newcommand{\DeclareMathDelimit}[2]{\newcommand{#1}[1]{\left#2\mitexrecurse{#1}\right#2}}\DeclareMathDelimit{\abs}{\vert}\abs{abc}"#), @r###"
     CommandName(Left)("\\left")

--- a/crates/mitex-parser/src/syntax.rs
+++ b/crates/mitex-parser/src/syntax.rs
@@ -47,6 +47,7 @@ pub enum SyntaxKind {
     ItemBegin,
     ItemEnd,
     ItemBlockComment,
+    ItemTypstCode,
     ItemAttachComponent,
     ItemFormula,
 

--- a/crates/mitex-parser/tests/ast.rs
+++ b/crates/mitex-parser/tests/ast.rs
@@ -23,6 +23,9 @@ mod ast {
     #[cfg(test)]
     mod left_right;
 
+    #[cfg(test)]
+    mod block_comment;
+
     /// Convenient function to launch/debug a test case
     #[test]
     fn bug_playground() {}

--- a/crates/mitex-parser/tests/ast/block_comment.rs
+++ b/crates/mitex-parser/tests/ast/block_comment.rs
@@ -1,0 +1,19 @@
+use super::prelude::*;
+
+#[test]
+fn base() {
+    assert_debug_snapshot!(parse(r#"\iffalse Test\fi"#), @r###"
+    root
+    |block-comment(space'(" "),word'("Test"))
+    "###);
+    assert_debug_snapshot!(parse(r#"\iffalse Test\else \LaTeX\fi"#), @r###"
+    root
+    |block-comment(space'(" "),word'("Test"))
+    |space'(" ")
+    |cmd(cmd-name("\\LaTeX"))
+    "###);
+    assert_debug_snapshot!(parse(r#"\iffalse Test\ifhbox Commented HBox\fi\fi"#), @r###"
+    root
+    |block-comment(space'(" "),word'("Test"),cmd-name("\\ifhbox"),space'(" "),word'("Commented"),space'(" "),word'("HBox"),cmd-name("\\fi"))
+    "###);
+}

--- a/crates/mitex-parser/tests/common/mod.rs
+++ b/crates/mitex-parser/tests/common/mod.rs
@@ -98,6 +98,7 @@ pub mod ast_snapshot {
                 SyntaxKind::ItemBegin => "begin",
                 SyntaxKind::ItemEnd => "end",
                 SyntaxKind::ItemBlockComment => "block-comment",
+                SyntaxKind::ItemTypstCode => "embedded-code",
                 SyntaxKind::ItemAttachComponent => "attach-comp",
                 SyntaxKind::ItemFormula => "formula",
                 SyntaxKind::ScopeRoot => "root",

--- a/crates/mitex/src/lib.rs
+++ b/crates/mitex/src/lib.rs
@@ -415,6 +415,9 @@ impl MathConverter {
 
                 self.exit_env(prev);
             }
+            ItemTypstCode => {
+                write!(f, "{}", elem.as_node().unwrap().text())?;
+            }
         };
 
         Ok(())
@@ -472,7 +475,7 @@ static DEFAULT_SPEC: once_cell::sync::Lazy<CommandSpec> = once_cell::sync::Lazy:
 
 #[cfg(test)]
 mod tests {
-    use insta::assert_debug_snapshot;
+    use insta::{assert_debug_snapshot, assert_snapshot};
 
     fn convert_math(input: &str) -> Result<String, String> {
         crate::convert_math(input, None)
@@ -851,5 +854,15 @@ a & b & c
         assert_debug_snapshot!(convert_math(r#"$\text{ab c}$"#).unwrap(), @r###""text(\"ab c\")""###);
         // note: hack doesn't work in this case
         assert_debug_snapshot!(convert_math(r#"$\text{ab\color{red}c}$"#).unwrap(), @r###""text(\"ab\\colorredc\")""###);
+    }
+
+    #[test]
+    fn test_convert_typst_code() {
+        assert_snapshot!(convert_math(r#"\iftypst#show: template\fi"#).unwrap(), @"#show: template");
+        assert_snapshot!(convert_math(r#"\iftypst#import "template.typ": project
+#show: project\fi"#).unwrap(), @r###"
+        #import "template.typ": project
+        #show: project
+        "###);
     }
 }


### PR DESCRIPTION
These commands are supported
+ \iffalse
+ \iftrue
+ \iftypst

Also supports `\iftypst`, see: 
```rs
    #[test]
    fn test_convert_typst_code() {
        assert_snapshot!(convert_math(r#"\iftypst#show: template\fi"#).unwrap(), @"#show: template");
        assert_snapshot!(convert_math(r#"\iftypst#import "template.typ": project
#show: project\fi"#).unwrap(), @r###"
        #import "template.typ": project
        #show: project
        "###);
    }
```