### PR TITLE
fix(lexer): test number of macro arguments before reading them

### DIFF
--- a/crates/mitex-lexer/src/macro_engine.rs
+++ b/crates/mitex-lexer/src/macro_engine.rs
@@ -768,12 +768,17 @@ impl<'a> MacroEngine<'a> {
         Some((name, action, m))
     }
 
+    // todo: insufficient macro arguments
     fn read_macro_args(
         ctx: &mut StreamContext<'a>,
         num_args: u8,
         opt: Option<Vec<Tok<'a>>>,
     ) -> Option<Vec<Vec<Tok<'a>>>> {
         let mut args = Vec::with_capacity(num_args as usize);
+
+        if num_args == 0 {
+            return Some(args);
+        }
 
         let mut num_of_read: u8 = 0;
         loop {

--- a/crates/mitex-lexer/tests/expand_macro.rs
+++ b/crates/mitex-lexer/tests/expand_macro.rs
@@ -85,7 +85,12 @@ fn get_macro(input: &str, macro_name: &str) -> String {
 
 #[test]
 fn ignoring_unimplemented() {
-    assert_snapshot!(r#"\AtEndOfClass{code}"#, @r###"\AtEndOfClass{code}"###);
+    assert_snapshot!(tokens(r#"\AtEndOfClass{code}"#), @r###"
+    CommandName(Generic)("\\AtEndOfClass")
+    Left(Curly)("{")
+    Word("code")
+    Right(Curly)("}")
+    "###);
 }
 
 #[test]
@@ -166,6 +171,9 @@ fn declare_macro() {
 
 #[test]
 fn subst_macro() {
+    // Description: zero arguments
+    assert_snapshot!(tokens(r#"\newcommand{\f}{f}\f"#), @r###"Word("f")"###);
+    // Description: reversed order of tokens
     assert_snapshot!(tokens(r#"\newcommand{\f}[2]{#1f(#2)}\f\hat xy"#), @r###"
     CommandName(Generic)("\\hat")
     Word("f")
@@ -174,7 +182,8 @@ fn subst_macro() {
     Right(Paren)(")")
     Word("y")
     "###);
-    assert_snapshot!(tokens(r#"\newenvironment{f}[2]{begin}{end}\begin{f}test\end{f}"#), @r###"
+    // Description: environment with macro
+    assert_snapshot!(tokens(r#"\newenvironment{f}{begin}{end}\begin{f}test\end{f}"#), @r###"
     Word("begin")
     Word("st")
     Word("end")

--- a/crates/mitex-lexer/tests/expand_macro.rs
+++ b/crates/mitex-lexer/tests/expand_macro.rs
@@ -185,7 +185,7 @@ fn subst_macro() {
     // Description: environment with macro
     assert_snapshot!(tokens(r#"\newenvironment{f}{begin}{end}\begin{f}test\end{f}"#), @r###"
     Word("begin")
-    Word("st")
+    Word("test")
     Word("end")
     "###);
 }


### PR DESCRIPTION
If not, arithmetic overflow happens if `num_args` equals to `0`.