### PR TITLE
feat: generate cmd spec or use prebuilt cmd spec in build.rs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with: { targets: wasm32-unknown-unknown }
       - uses: mozilla-actions/sccache-action@v0.0.3
-      - run: sh scripts/build.sh
       - run: cargo test --workspace --no-fail-fast
   checks:
     name: Check clippy, formatting, and documentation
@@ -35,7 +34,19 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with: { targets: wasm32-unknown-unknown }
       - uses: mozilla-actions/sccache-action@v0.0.3
-      - run: sh scripts/build.sh
       - run: cargo clippy --workspace --all-targets --all-features
       - run: cargo fmt --check --all
       - run: cargo doc --workspace --no-deps
+  build-wasm-plugin:
+    name: Build WASM plugin for Typst
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: recursive }
+      - uses: typst-community/setup-typst@v3
+        with: { typst-version: "0.10.0" }
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@stable
+        with: { targets: wasm32-unknown-unknown }
+      - uses: mozilla-actions/sccache-action@v0.0.3
+      - run: sh scripts/build.sh

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "assets/artifacts"]
+	path = assets/artifacts
+	url = https://github.com/mitex-rs/artifacts
+	branch = v0.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
+name = "anyhow"
+version = "1.0.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca87830a3e3fb156dc96cfbd31cb620265dd053be734723f22b760d6cc3c3051"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +177,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ea5e3f9cda726431da9d1a8d5a29785d544b31e98e1ca7a210906244002e02"
 
 [[package]]
+name = "either"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+
+[[package]]
 name = "ena"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,6 +253,15 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "insta"
@@ -340,6 +361,7 @@ dependencies = [
  "divan",
  "insta",
  "mitex-parser",
+ "mitex-spec-gen",
  "once_cell",
  "rowan",
  "serde",
@@ -370,6 +392,7 @@ dependencies = [
  "insta",
  "logos",
  "mitex-spec",
+ "mitex-spec-gen",
  "once_cell",
 ]
 
@@ -382,6 +405,7 @@ dependencies = [
  "mitex-glob",
  "mitex-lexer",
  "mitex-spec",
+ "mitex-spec-gen",
  "once_cell",
  "rowan",
 ]
@@ -396,6 +420,17 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "mitex-spec-gen"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "mitex-spec",
+ "serde",
+ "serde_json",
+ "which",
 ]
 
 [[package]]
@@ -697,6 +732,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "venial",
+]
+
+[[package]]
+name = "which"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = ["crates/*"]
 [workspace.dependencies]
 
 once_cell = "1"
+anyhow = "1"
 
 fxhash = "0.2.1"
 ecow = "0.2.0"
@@ -23,6 +24,8 @@ ena = "0.14.2"
 
 logos = "0.13.0"
 rowan = "0.15.15"
+
+which = "5.0.0"
 
 divan = "0.1.7"
 insta = "1.34"

--- a/crates/mitex-lexer/Cargo.toml
+++ b/crates/mitex-lexer/Cargo.toml
@@ -19,6 +19,8 @@ fxhash.workspace = true
 once_cell.workspace = true
 
 [dev-dependencies]
+mitex-spec-gen = { path = "../mitex-spec-gen" }
+
 insta.workspace = true
 divan.workspace = true
 

--- a/crates/mitex-parser/Cargo.toml
+++ b/crates/mitex-parser/Cargo.toml
@@ -23,9 +23,12 @@ mitex-spec = { path = "../mitex-spec" }
 rowan.workspace = true
 
 [dev-dependencies]
-once_cell = "1"
-insta = "1.34"
-divan = "0.1.7"
+
+mitex-spec-gen = { path = "../mitex-spec-gen" }
+
+once_cell.workspace = true
+insta.workspace = true
+divan.workspace = true
 
 [lints]
 workspace = true

--- a/crates/mitex-spec-gen/Cargo.toml
+++ b/crates/mitex-spec-gen/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "mitex-spec-gen"
+description = "Guard to geneate specification files for dependent crates"
+authors.workspace = true
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[build-dependencies]
+mitex-spec = { path = "../mitex-spec" }
+serde.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+which.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+# use prebuilt spec data
+prebuilt = []
+# generate spec data
+generate = []

--- a/crates/mitex-spec-gen/build.rs
+++ b/crates/mitex-spec-gen/build.rs
@@ -1,0 +1,125 @@
+//! Common build script for crates depending on the compacted default
+//! specification.
+
+use std::path::PathBuf;
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+fn main() {
+    let spec_builder = if cfg!(feature = "prebuilt") {
+        copy_prebuilt
+    } else if cfg!(feature = "generate") || which::which("typst").is_ok() {
+        generate
+    } else {
+        // fallback to prebuilt spec
+        copy_prebuilt
+    };
+
+    spec_builder()
+        .with_context(|| "failed to build spec")
+        .unwrap();
+}
+
+fn get_project_root() -> anyhow::Result<PathBuf> {
+    let project_root =
+        std::env::var("CARGO_MANIFEST_DIR").with_context(|| "failed to get project root")?;
+    Ok(std::path::Path::new(&project_root)
+        .parent()
+        .with_context(|| "failed to get project root")?
+        .parent()
+        .with_context(|| "failed to get project root")?
+        .to_owned())
+}
+
+fn copy_prebuilt() -> anyhow::Result<()> {
+    // println!("cargo:warning=copy_prebuilt");
+    let project_root = get_project_root()?;
+
+    // assets/artifacts/spec/default.rkyv
+    std::fs::create_dir_all(project_root.join("target/mitex-artifacts/spec"))
+        .with_context(|| "failed to create target_dir for store spec")?;
+
+    let prebuilt_spec = project_root.join("assets/artifacts/spec/default.rkyv");
+    let target_spec = project_root.join("target/mitex-artifacts/spec/default.rkyv");
+
+    std::fs::copy(prebuilt_spec, target_spec).with_context(|| {
+        "failed to copy prebuilt spec, \
+    do you forget to run `git submodule update --init`?"
+    })?;
+
+    Ok(())
+}
+
+fn generate() -> anyhow::Result<()> {
+    // println!("cargo:warning=generate");
+
+    // require rustc 1.70.0
+    println!("cargo:rerun-if-changed=ALWAYS_RUN_ME");
+
+    // typst query --root . ./packages/latex-spec/mod.typ "<mitex-packages>"
+    let project_root = get_project_root()?;
+
+    let target_dir = project_root.join("target/mitex-artifacts");
+
+    let package_specs = std::process::Command::new("typst")
+        .args([
+            "query",
+            "--root",
+            project_root.to_str().unwrap(),
+            project_root
+                .join("packages/mitex/specs/mod.typ")
+                .to_str()
+                .unwrap(),
+            "<mitex-packages>",
+        ])
+        .output()
+        .with_context(|| "failed to query metadata")?;
+
+    #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+    struct QueryItem<T> {
+        pub value: T,
+    }
+
+    type Json<T> = Vec<QueryItem<T>>;
+
+    let mut json_spec: mitex_spec::JsonCommandSpec = Default::default();
+    let json_packages: Json<mitex_spec::query::PackagesVec> =
+        serde_json::from_slice(&package_specs.stdout).expect("failed to parse package specs");
+    if json_packages.is_empty() {
+        panic!("no package found");
+    }
+    if json_packages.len() > 1 {
+        panic!("multiple packages found");
+    }
+
+    std::fs::create_dir_all(target_dir.join("spec"))
+        .with_context(|| "failed to create target_dir for store spec")?;
+
+    let json_packages = json_packages.into_iter().next().unwrap().value;
+    std::fs::write(
+        target_dir.join("spec/packages.json"),
+        serde_json::to_string_pretty(&json_packages)
+            .with_context(|| "failed to serialize json packages")?,
+    )
+    .with_context(|| "failed to write json packages")?;
+
+    for package in json_packages.0 {
+        for (name, item) in package.spec.commands {
+            json_spec.commands.insert(name, item);
+        }
+    }
+    std::fs::write(
+        target_dir.join("spec/default.json"),
+        serde_json::to_string_pretty(&json_spec)
+            .with_context(|| "failed to serialize json spec")?,
+    )
+    .with_context(|| "failed to write json spec")?;
+
+    let spec: mitex_spec::CommandSpec = json_spec.into();
+
+    std::fs::write(target_dir.join("spec/default.rkyv"), spec.to_bytes())
+        .with_context(|| "failed to write compacted spec")?;
+
+    Ok(())
+}

--- a/crates/mitex-spec-gen/build.rs
+++ b/crates/mitex-spec-gen/build.rs
@@ -42,6 +42,7 @@ fn copy_prebuilt() -> anyhow::Result<()> {
 
     let prebuilt_spec = project_root.join("assets/artifacts/spec/default.rkyv");
     let target_spec = project_root.join("target/mitex-artifacts/spec/default.rkyv");
+    println!("cargo:warning=Use prebuilt spec binaries at {prebuilt_spec:?}");
 
     std::fs::copy(prebuilt_spec, target_spec).with_context(|| {
         "failed to copy prebuilt spec, \

--- a/crates/mitex-spec-gen/src/lib.rs
+++ b/crates/mitex-spec-gen/src/lib.rs
@@ -1,0 +1,1 @@
+//! Generate Default Command Specification for embedded LaTeX packages.

--- a/crates/mitex/Cargo.toml
+++ b/crates/mitex/Cargo.toml
@@ -15,6 +15,7 @@ harness = false
 [dependencies]
 
 mitex-parser = { path = "../mitex-parser" }
+mitex-spec-gen = { path = "../mitex-spec-gen" }
 rowan.workspace = true
 bitflags = "2.4.1"
 once_cell.workspace = true

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,4 +1,6 @@
-cargo run --release --bin mitex
 cargo build --release --target wasm32-unknown-unknown -p mitex-typst
-rm packages/mitex/mitex.wasm -Force
-mv target/wasm32-unknown-unknown/release/mitex_typst.wasm packages/mitex/mitex.wasm
+$InstallPath = "packages/mitex/mitex.wasm"
+if (Test-Path $InstallPath) {
+  Remove-Item $InstallPath
+}
+mv target/wasm32-unknown-unknown/release/mitex_typst.wasm $InstallPath

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-cargo run --release --bin mitex
 cargo build --release --target wasm32-unknown-unknown -p mitex-typst
 rm -f packages/mitex/mitex.wasm
 mv target/wasm32-unknown-unknown/release/mitex_typst.wasm packages/mitex/mitex.wasm


### PR DESCRIPTION
The key code is here

https://github.com/mitex-rs/mitex/blob/ed4a57cbe7ac9a7668ff4fc019a120633c63d76f/crates/mitex-spec-gen/build.rs#L10-L17

Three mode.
+ if specified feature `prebuilt`, get spec by running `copy_prebuilt`.
+ otherwise, if specified feature `generate`, get spec by running `generate`.
+ otherwise, in default, if users have typst-cli installed, run `generate`, otherwise run `copy_prebuilt`.
  
  ```rs
  if which::which("typst").is_ok() { 
     generate 
  } else { 
    // fallback to prebuilt spec 
    copy_prebuilt 
  }
  ```
