### PR TITLE
dev(cli): fix readme, command, build script, and compile result

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ In addition, MiTeX is not only **SMALL** but also **FAST**! MiTeX has a size of 
 
 Thanks to [@Myriad-Dreamin](https://github.com/Myriad-Dreamin), he completed the most complex development work: developing the parser for generating AST.
 
-## Usage
+## MiTeX as a Typst Package
 
 - Use `mitex-convert` to convert LaTeX code into Typst code in string.
 - Use `mi` to render an inline LaTeX equation in Typst.
@@ -47,7 +47,7 @@ We also support text mode (in development):
   \section{Title}
 
   A \textbf{strong} text, a \emph{emph} text and inline equation $x + y$.
-  
+
   Also block \eqref{eq:pythagoras}.
 
   \begin{equation}
@@ -57,6 +57,20 @@ We also support text mode (in development):
 ```
 
 ![example](packages/mitex/examples/example.png)
+
+## MiTeX as a CLI Tool
+
+### Installation
+
+Install it by `cargo install mitex-cli` or install latest nightly version by `cargo install --git https://github.com/mitex-rs/mitex mitex-cli`.
+
+### Usage
+
+```bash
+mitex compile main.tex
+# or (same as above)
+mitex compile main.tex mitex.typ
+```
 
 ## Implemented Features
 

--- a/crates/mitex-cli/src/main.rs
+++ b/crates/mitex-cli/src/main.rs
@@ -74,7 +74,7 @@ fn compile(input_path: &str, output_path: &str, is_ast: bool) -> Result<(), Erro
         .with_context(|| format!("failed to read input file: {input_path}"))?;
 
     let output = if !is_ast {
-        mitex::convert_math(&input, None).map_err(|e| anyhow::anyhow!("{}", e))
+        mitex::convert_text(&input, None).map_err(|e| anyhow::anyhow!("{}", e))
     } else {
         Ok(format!(
             "{:#?}",

--- a/crates/mitex-spec-gen/build.rs
+++ b/crates/mitex-spec-gen/build.rs
@@ -55,11 +55,14 @@ fn copy_prebuilt() -> anyhow::Result<()> {
 fn generate() -> anyhow::Result<()> {
     // println!("cargo:warning=generate");
 
-    // require rustc 1.70.0
-    println!("cargo:rerun-if-changed=ALWAYS_RUN_ME");
-
     // typst query --root . ./packages/latex-spec/mod.typ "<mitex-packages>"
     let project_root = get_project_root()?;
+
+    let spec_root = project_root.join("packages/mitex/specs/");
+    println!(
+        "cargo:rerun-if-changed={spec_root}",
+        spec_root = spec_root.display()
+    );
 
     let target_dir = project_root.join("target/mitex-artifacts");
 

--- a/crates/mitex-spec/src/lib.rs
+++ b/crates/mitex-spec/src/lib.rs
@@ -99,6 +99,11 @@ impl CommandSpec {
         self.0.commands.get(name)
     }
 
+    /// Iterate all items
+    pub fn items(&self) -> impl Iterator<Item = (&str, &CommandSpecItem)> {
+        self.0.commands.iter().map(|(k, v)| (k.as_str(), v))
+    }
+
     /// Get an item by name in kind of _command_
     pub fn get_cmd(&self, name: &str) -> Option<&CmdShape> {
         self.get(name).and_then(|item| {


### PR DESCRIPTION
+ Add cli usage to readme.
+ Use new text mode in compile command
+ Restrict build constraints for mitex-cli, so that it doesn't always compile by `cargo run --bin mitex`.
+ insert handler definitions in `mitex-scope` before the transpiled document. They look like:
  ```typ
  #import "@preview/mitex:0.1.0": *
  #let mitexarray = mitex-scope.at("mitexarray", default: none);
  #let mitexbold = mitex-scope.at("mitexbold", default: none);
  #let mitexcal = mitex-scope.at("mitexcal", default: none);
  ...
  ```