### PR TITLE
fix: set base in gh pages workflow

### DIFF
--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -41,7 +41,7 @@ jobs:
       - run: | # Run tests
           cd packages/mitex-web
           yarn
-          yarn build
+          yarn build --base=/mitex
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact


### PR DESCRIPTION
https://vitejs.dev/guide/build#public-base-path