### PR TITLE
test: add afl fuzzer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "afl"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca431c501c567ea9a4e52c2ebca418299b8201afc15e6ea47584733f0faf9780"
+dependencies = [
+ "home",
+ "libc",
+ "rustc_version",
+ "xdg",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,6 +339,19 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "fuzz-target-mitex"
+version = "0.1.0"
+dependencies = [
+ "afl",
+ "divan",
+ "insta",
+ "mitex",
+ "rowan",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "fxhash"
@@ -1244,6 +1269,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xdg"
+version = "2.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213b7324336b53d2414b2db8537e56544d981803139155afa84f76eeebb7a546"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.74"
 
 [workspace]
 resolver = "2"
-members = ["crates/*"]
+members = ["crates/*", "fuzz/*"]
 
 [workspace.dependencies]
 

--- a/fuzz/mitex/Cargo.toml
+++ b/fuzz/mitex/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "fuzz-target-mitex"
+authors.workspace = true
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+
+[dependencies]
+afl = "*"
+mitex = { path = "../../crates/mitex" }
+rowan.workspace = true
+
+[dev-dependencies]
+insta.workspace = true
+divan.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+

--- a/fuzz/mitex/Cargo.toml
+++ b/fuzz/mitex/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 
 [dependencies]
-afl = "*"
+afl = "0.15"
 mitex = { path = "../../crates/mitex" }
 rowan.workspace = true
 

--- a/fuzz/mitex/src/main.rs
+++ b/fuzz/mitex/src/main.rs
@@ -1,0 +1,8 @@
+use afl::fuzz;
+fn main() {
+    fuzz!(|data: &[u8]| {
+        if let Ok(s) = std::str::from_utf8(data) {
+            let _ = mitex::convert_math(s, None);
+        }
+    });
+}


### PR DESCRIPTION
## Usage

First prepare a bunch of tex input, I suggest the top 50 of oiwiki:
```js
const test = require('./oiwiki-231222.json')
const fs = require('fs');
// write each test case to a file in a subdirectory

for (const [i, t] of test.entries()) {
  fs.writeFileSync(`./seed/${i}.txt`, t.text);
  if (i > 50) {
    break;
  }
}
```

Then build and fuzz
```
cargo afl build --bin fuzz-target-mitex
cargo afl fuzz -i local/seed -o local/fuzz-res ./target/debug/fuzz-target-mitex
```

To minimize test case, using afl-tmin
```
cargo afl tmin -i crash.tex -o minimized.tex ./target/debug/fuzz-target-mitex
```