### PR TITLE
fix: remove extra spacing for ceiling symbols

### DIFF
--- a/packages/mitex/specs/latex/standard.typ
+++ b/packages/mitex/specs/latex/standard.typ
@@ -102,9 +102,9 @@
   rVert: define-sym("||"),
   lparen: define-sym("paren.l"),
   rparen: define-sym("paren.r"),
-  lceil: define-sym(" ⌈ "),
-  rceil: define-sym("⌉ "),
-  lfloor: define-sym("⌊ "),
+  lceil: define-sym("⌈"),
+  rceil: define-sym("⌉"),
+  lfloor: define-sym("⌊"),
   rfloor: define-sym("⌋"),
   // Sizes and styles
   displaystyle: greedy-handle("mitexdisplay", math.display),


### PR DESCRIPTION
Should resolve #121. 

If there are additional changes that need to happen, please let me know and I'll make them. Also feel free to just edit the PR.