### PR TITLE
feat: add support for `\(\)` and `\[\]` instead of `$`'s

### DIFF
--- a/crates/mitex-lexer/src/token.rs
+++ b/crates/mitex-lexer/src/token.rs
@@ -249,17 +249,15 @@ fn lex_command_name(lexer: &mut logos::Lexer<Token>) -> CommandName {
     // is a valid escape sequence
     lexer.bump(c.len_utf8());
 
+    // Lex the command name if it is not an escape sequence
     match c {
         '(' => return CommandName::BeginMathInline,
         ')' => return CommandName::EndMathInline,
         '[' => return CommandName::BeginMathDisplay,
         ']' => return CommandName::EndMathDisplay,
+        '@' => {}
+        _ if !c.is_ascii_alphabetic() => return CommandName::Generic,
         _ => {}
-    }
-
-    // Lex the command name if it is not an escape sequence
-    if !c.is_ascii_alphabetic() && c != '@' {
-        return CommandName::Generic;
     }
 
     // Case3 (Rest): lex a general ascii command name

--- a/crates/mitex-lexer/src/token.rs
+++ b/crates/mitex-lexer/src/token.rs
@@ -180,6 +180,14 @@ pub enum CommandName {
     BeginEnvironment,
     /// clause of Environment: \end
     EndEnvironment,
+    /// clause of Math: \(
+    BeginMathInline,
+    /// clause of Math: \)
+    EndMathInline,
+    /// clause of Math: \[
+    BeginMathDisplay,
+    /// clause of Math: \]
+    EndMathDisplay,
     /// clause of Environment: \begin, but error
     ErrorBeginEnvironment,
     /// clause of Environment: \end, but error
@@ -240,6 +248,15 @@ fn lex_command_name(lexer: &mut logos::Lexer<Token>) -> CommandName {
     // Note: the first char is always legal, since a backslash with any single char
     // is a valid escape sequence
     lexer.bump(c.len_utf8());
+
+    match c {
+        '(' => return CommandName::BeginMathInline,
+        ')' => return CommandName::EndMathInline,
+        '[' => return CommandName::BeginMathDisplay,
+        ']' => return CommandName::EndMathDisplay,
+        _ => {}
+    }
+
     // Lex the command name if it is not an escape sequence
     if !c.is_ascii_alphabetic() && c != '@' {
         return CommandName::Generic;

--- a/crates/mitex-parser/src/parser.rs
+++ b/crates/mitex-parser/src/parser.rs
@@ -434,7 +434,11 @@ impl<'a, S: TokenStream<'a>> Parser<'a, S> {
                 CommandName::Left => self.item_lr(),
                 CommandName::Right => return self.command(),
                 CommandName::ErrorBeginEnvironment | CommandName::ErrorEndEnvironment => self.eat(),
-                CommandName::EndMathInline | CommandName::EndMathDisplay => return false,
+                CommandName::EndMathInline | CommandName::EndMathDisplay => {
+                    self.builder.start_node(TokenError.into());
+                    self.eat();
+                    self.builder.finish_node();
+                }
             },
         }
 

--- a/crates/mitex-parser/src/parser.rs
+++ b/crates/mitex-parser/src/parser.rs
@@ -271,6 +271,7 @@ impl<'a, S: TokenStream<'a>> Parser<'a, S> {
                 kind,
                 Token::Right(BraceKind::Curly)
                     | Token::CommandName(CommandName::EndEnvironment | CommandName::Right)
+                    | Token::CommandName(CommandName::EndMathInline | CommandName::EndMathDisplay)
                     | Token::Dollar
             ),
             ParseScope::Environment => matches!(
@@ -341,7 +342,18 @@ impl<'a, S: TokenStream<'a>> Parser<'a, S> {
         self.builder.start_node(group_kind.into());
         self.eat();
         self.item_list(scope);
-        self.eat_if(end_token);
+
+        if end_token == Token::Dollar
+            && matches!(
+                end_token,
+                Token::Dollar
+                    | Token::CommandName(CommandName::EndMathInline | CommandName::EndMathDisplay)
+            )
+        {
+            self.eat()
+        } else {
+            self.eat_if(end_token);
+        }
         self.builder.finish_node();
     }
 
@@ -410,6 +422,10 @@ impl<'a, S: TokenStream<'a>> Parser<'a, S> {
                 CommandName::Generic => return self.command(),
                 CommandName::BeginEnvironment => self.environment(),
                 CommandName::EndEnvironment => return self.command(),
+                CommandName::BeginMathInline | CommandName::BeginMathDisplay => {
+                    self.item_group(ItemFormula);
+                    return false;
+                }
                 CommandName::If(IfCommandName::IfFalse) => self.block_comment(),
                 CommandName::If(IfCommandName::IfTypst) => self.typst_code(),
                 CommandName::If(..) | CommandName::Else | CommandName::EndIf => {
@@ -418,6 +434,7 @@ impl<'a, S: TokenStream<'a>> Parser<'a, S> {
                 CommandName::Left => self.item_lr(),
                 CommandName::Right => return self.command(),
                 CommandName::ErrorBeginEnvironment | CommandName::ErrorEndEnvironment => self.eat(),
+                CommandName::EndMathInline | CommandName::EndMathDisplay => return false,
             },
         }
 

--- a/crates/mitex-parser/src/syntax.rs
+++ b/crates/mitex-parser/src/syntax.rs
@@ -65,6 +65,8 @@ pub enum SyntaxKind {
     TokenSlash,
     TokenWord,
     TokenDollar,
+    TokenStartMath,
+    TokenEndMath,
     TokenAmpersand,
     TokenHash,
     TokenUnderscore,
@@ -133,12 +135,12 @@ impl From<Token> for SyntaxKind {
             Token::CommandName(CommandName::BeginEnvironment | CommandName::EndEnvironment) => {
                 SyntaxKind::TokenCommandSym
             }
-            Token::CommandName(
-                CommandName::BeginMathInline
-                | CommandName::BeginMathDisplay
-                | CommandName::EndMathInline
-                | CommandName::EndMathDisplay,
-            ) => SyntaxKind::TokenDollar,
+            Token::CommandName(CommandName::BeginMathInline | CommandName::BeginMathDisplay) => {
+                SyntaxKind::TokenStartMath
+            }
+            Token::CommandName(CommandName::EndMathInline | CommandName::EndMathDisplay) => {
+                SyntaxKind::TokenEndMath
+            }
             Token::CommandName(_) => SyntaxKind::ClauseCommandName,
         }
     }
@@ -238,14 +240,16 @@ impl FormulaItem {
     /// Checks whether it is a display formula
     pub fn is_display(&self) -> bool {
         self.syntax().first_token().map_or(false, |node| {
-            node.kind() == TokenDollar && (node.text() == "$$" || node.text() == "\\[")
+            (node.kind() == TokenDollar && node.text() == "$$")
+                || (node.kind() == TokenStartMath && node.text() == "\\[")
         })
     }
 
     /// Checks whether it is an inline formula
     pub fn is_inline(&self) -> bool {
         self.syntax().first_token().map_or(false, |node| {
-            node.kind() == TokenDollar && (node.text() == "$" || node.text() == "\\(")
+            (node.kind() == TokenDollar && node.text() == "$")
+                || (node.kind() == TokenStartMath && node.text() == "\\(")
         })
     }
 }

--- a/crates/mitex-parser/src/syntax.rs
+++ b/crates/mitex-parser/src/syntax.rs
@@ -133,6 +133,12 @@ impl From<Token> for SyntaxKind {
             Token::CommandName(CommandName::BeginEnvironment | CommandName::EndEnvironment) => {
                 SyntaxKind::TokenCommandSym
             }
+            Token::CommandName(
+                CommandName::BeginMathInline
+                | CommandName::BeginMathDisplay
+                | CommandName::EndMathInline
+                | CommandName::EndMathDisplay,
+            ) => SyntaxKind::TokenDollar,
             Token::CommandName(_) => SyntaxKind::ClauseCommandName,
         }
     }
@@ -232,14 +238,14 @@ impl FormulaItem {
     /// Checks whether it is a display formula
     pub fn is_display(&self) -> bool {
         self.syntax().first_token().map_or(false, |node| {
-            node.kind() == TokenDollar && node.text() == "$$"
+            node.kind() == TokenDollar && (node.text() == "$$" || node.text() == "\\[")
         })
     }
 
     /// Checks whether it is an inline formula
     pub fn is_inline(&self) -> bool {
         self.syntax().first_token().map_or(false, |node| {
-            node.kind() == TokenDollar && node.text() == "$"
+            node.kind() == TokenDollar && (node.text() == "$" || node.text() == "\\(")
         })
     }
 }

--- a/crates/mitex-parser/tests/common/mod.rs
+++ b/crates/mitex-parser/tests/common/mod.rs
@@ -70,6 +70,8 @@ pub mod ast_snapshot {
                 SyntaxKind::TokenSlash => "slash'",
                 SyntaxKind::TokenWord => "word'",
                 SyntaxKind::TokenDollar => "dollar'",
+                SyntaxKind::TokenStartMath => "start-math'",
+                SyntaxKind::TokenEndMath => "end-math",
                 SyntaxKind::TokenAmpersand => "ampersand'",
                 SyntaxKind::TokenHash => "hash'",
                 SyntaxKind::TokenUnderscore => "underscore'",

--- a/crates/mitex/src/lib.rs
+++ b/crates/mitex/src/lib.rs
@@ -286,7 +286,8 @@ impl Converter {
                 }
             }
             // do nothing
-            TokenLBrace | TokenRBrace | TokenDollar | TokenComment | ItemBlockComment => {}
+            TokenLBrace | TokenRBrace | TokenDollar | TokenStartMath | TokenEndMath
+            | TokenComment | ItemBlockComment => {}
             // space identical
             TokenWhiteSpace => {
                 if self.skip_next_space {


### PR DESCRIPTION
Not too sure on some of the organization, particularly treating `\(` and `\[` as dollars syntactically. 

```typst
#import "packages/mitex/mitex.typ": *

= Converted

#let test_text = "
  \\(1 + 2\\)
  \\[1 + 2\\]
"

#raw(mitex-convert(mode: "text", test_text))
= Rendered

#eval(
  mitex-convert(mode: "text", test_text), mode: "markup", scope: mitex-scope,
)
```

gives 

<img width="265" alt="image" src="https://github.com/mitex-rs/mitex/assets/70821802/385fe260-e79e-4140-9591-357c83e1e1b0">

Closes #124 