### PR TITLE
fix: parse bracket/paren group only if as argument

### DIFF
--- a/crates/mitex-parser/src/parser.rs
+++ b/crates/mitex-parser/src/parser.rs
@@ -396,15 +396,6 @@ impl<'a, S: TokenStream<'a>> Parser<'a, S> {
                 self.eat();
                 self.builder.finish_node();
             }
-            // todo: check if this is correct
-            // self.expect2(Token::Right(BraceKind::Bracket), Token::Right(BraceKind::Paren));
-            // alternative self.expect(tok);
-            Token::Left(BraceKind::Bracket) if not_prefer_single_char => {
-                self.item_group(ParseScope::BracketItem)
-            }
-            Token::Left(BraceKind::Paren) if not_prefer_single_char => {
-                self.item_group(ParseScope::ParenItem)
-            }
             Token::Left(..)
             | Token::Right(..)
             | Token::Tilde

--- a/crates/mitex-parser/tests/ast.rs
+++ b/crates/mitex-parser/tests/ast.rs
@@ -9,6 +9,9 @@ mod ast {
     use prelude::*;
 
     #[cfg(test)]
+    mod arg_parse;
+
+    #[cfg(test)]
     mod arg_match;
 
     #[cfg(test)]

--- a/crates/mitex-parser/tests/ast/arg_parse.rs
+++ b/crates/mitex-parser/tests/ast/arg_parse.rs
@@ -1,0 +1,56 @@
+use super::prelude::*;
+
+/// Argument will reset flag of being in a formula
+#[test]
+fn arg_scope() {
+    assert_debug_snapshot!(parse(r#"$\text{${1}$}$"#), @r###"
+    root
+    |formula
+    ||dollar'("$")
+    ||cmd
+    |||cmd-name("\\text")
+    |||args
+    ||||curly
+    |||||lbrace'("{")
+    |||||formula
+    ||||||dollar'("$")
+    ||||||curly
+    |||||||lbrace'("{")
+    |||||||text(word'("1"))
+    |||||||rbrace'("}")
+    ||||||dollar'("$")
+    |||||rbrace'("}")
+    ||dollar'("$")
+    "###);
+    // Note: This is a valid AST, but semantically incorrect (indicated by overleaf)
+    assert_debug_snapshot!(parse(r#"$\frac{${1}$}{${2}$}$"#), @r###"
+    root
+    |formula
+    ||dollar'("$")
+    ||cmd
+    |||cmd-name("\\frac")
+    |||args
+    ||||curly
+    |||||lbrace'("{")
+    |||||formula
+    ||||||dollar'("$")
+    ||||||curly
+    |||||||lbrace'("{")
+    |||||||text(word'("1"))
+    |||||||rbrace'("}")
+    ||||||dollar'("$")
+    |||||rbrace'("}")
+    |||args
+    ||||curly
+    |||||lbrace'("{")
+    |||||formula
+    ||||||dollar'("$")
+    ||||||curly
+    |||||||lbrace'("{")
+    |||||||text(word'("2"))
+    |||||||rbrace'("}")
+    ||||||dollar'("$")
+    |||||rbrace'("}")
+    ||dollar'("$")
+    "###);
+}

--- a/crates/mitex-parser/tests/ast/formula.rs
+++ b/crates/mitex-parser/tests/ast/formula.rs
@@ -30,3 +30,64 @@ fn cmd_formula() {
     |formula(begin-math'("\\("),end-math("\\]"))
     "###);
 }
+
+#[test]
+fn formula_scope() {
+    assert_debug_snapshot!(parse(r#"$[)$ test"#), @r###"
+    root
+    |formula(dollar'("$"),lbracket'("["),rparen'(")"),dollar'("$"))
+    |space'(" ")
+    |text(word'("test"))
+    "###);
+}
+
+#[test]
+fn curly_scope() {
+    // Note: this is a broken AST
+    assert_debug_snapshot!(parse(r#"${$}"#), @r###"
+    root
+    |formula
+    ||dollar'("$")
+    ||curly
+    |||lbrace'("{")
+    |||formula(dollar'("$"))
+    |||rbrace'("}")
+    "###);
+    // Note: this is a valid but incompleted AST, converter should handle it
+    // correctly
+    assert_debug_snapshot!(parse(r#"{$}$"#), @r###"
+    root
+    |curly
+    ||lbrace'("{")
+    ||formula(dollar'("$"))
+    ||rbrace'("}")
+    |formula(dollar'("$"))
+    "###);
+}
+
+#[test]
+fn env_scope() {
+    // Note: this is a valid but incompleted AST, converter should handle it
+    // correctly
+    assert_debug_snapshot!(parse(r#"\begin{array}$\end{array}$"#), @r###"
+    root
+    |env
+    ||begin
+    |||sym'("array")
+    |||args
+    ||||formula(dollar'("$"))
+    ||end(sym'("array"))
+    |formula(dollar'("$"))
+    "###);
+    // Note: this is a valid but incompleted AST, converter should handle it
+    // correctly
+    assert_debug_snapshot!(parse(r#"$\begin{array}$\end{array}"#), @r###"
+    root
+    |formula
+    ||dollar'("$")
+    ||env
+    |||begin(sym'("array"))
+    |||formula(dollar'("$"))
+    |||end(sym'("array"))
+    "###);
+}


### PR DESCRIPTION
Fix #130. #130 should be closed since this PR fix the first point of #130 and the second point of #130 is duplicated. 

This is the case to fix:

https://github.com/mitex-rs/mitex/blob/d75f54bf4c265d369d5c445edfb5e99bab94b3fc/crates/mitex-parser/tests/ast/formula.rs#L34-L42

All bracket/paren are viewed as normal text if they are not matched as an argument of some command.
