### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PS: `#set math.equation(numbering: "(1)")` is also valid for MiTeX.
 Following is [a simple example](https://github.com/mitex-rs/mitex/blob/main/packages/mitex/examples/example.typ) of using MiTeX in Typst:
 
 ```typst
-#import "@preview/mitex:0.2.1": *
+#import "@preview/mitex:0.2.2": *
 
 #assert.eq(mitex-convert("\alpha x"), "alpha  x ")
 

--- a/crates/mitex-cli/src/main.rs
+++ b/crates/mitex-cli/src/main.rs
@@ -121,7 +121,7 @@ fn compile(input_path: &str, output_path: &str, is_ast: bool) -> Result<(), Erro
         output_path,
         format!(
             r#"
-#import "@preview/mitex:0.1.0": *
+#import "@preview/mitex:0.2.2": *
 {preludes_str}
 
 {output}"#

--- a/fixtures/underleaf/ieee/main.typ
+++ b/fixtures/underleaf/ieee/main.typ
@@ -1,5 +1,5 @@
 
-#import "@preview/mitex:0.2.1": *
+#import "@preview/mitex:0.2.2": *
 
 #let res = mitex-convert(mode: "text", read("main.tex"))
 #eval(res, mode: "markup", scope: mitex-scope)

--- a/packages/mitex-web/src/main.ts
+++ b/packages/mitex-web/src/main.ts
@@ -58,7 +58,7 @@ const App = () => {
     van.derive(async () => {
       if (fontLoaded.val) {
         svgData.val = await $typst.svg({
-          mainContent: `#import "@preview/mitex:0.1.0": *
+          mainContent: `#import "@preview/mitex:0.2.2": *
         #set page(width: auto, height: auto, margin: 1em);
         #set text(size: 24pt);
         ${darkModeStyle.val}
@@ -128,7 +128,7 @@ const App = () => {
     CopyButton(
       "Copy with template and imports",
       van.derive(
-        () => `#import "@preview/mitex:0.1.0": *\n
+        () => `#import "@preview/mitex:0.2.2": *\n
 #math.equation(eval("$" + \`${output.val}\`.text + "$", mode: "markup", scope: mitex-scope), block: true)`
       )
     ),

--- a/packages/mitex/README.md
+++ b/packages/mitex/README.md
@@ -22,7 +22,7 @@ PS: `#set math.equation(numbering: "(1)")` is also valid for MiTeX.
 Following is [a simple example](https://github.com/mitex-rs/mitex/blob/main/packages/mitex/examples/example.typ) of using MiTeX in Typst:
 
 ```typst
-#import "@preview/mitex:0.2.1": *
+#import "@preview/mitex:0.2.2": *
 
 #assert.eq(mitex-convert("\alpha x"), "alpha  x ")
 

--- a/packages/mitex/examples/example.typ
+++ b/packages/mitex/examples/example.typ
@@ -1,4 +1,4 @@
-#import "../lib.typ": *
+#import "@preview/mitex:0.2.2": *
 
 #set page(width: 500pt, height: auto, margin: 1em)
 

--- a/packages/mitex/typst.toml
+++ b/packages/mitex/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mitex"
-version = "0.2.1"
+version = "0.2.2"
 entrypoint = "lib.typ"
 authors = ["Myriad-Dreamin", "OrangeX4", "Enter-tainer"]
 license = "Apache-2.0"


### PR DESCRIPTION
bump version to 0.2.2

# Changelog

1. **Urgent fix:** remove duplicate keys for error when a dict has duplicate keys in 0.11
2. fix: parse bracket/paren group
3. fix: remove extra spacing for ceiling symbols
4. feat: add support for `\(\)` and `\[\]`
5. feat: support footnote and cite