### PR TITLE
refactor: convert \text{} to \textmath[]

### DIFF
--- a/crates/mitex-lexer/src/token.rs
+++ b/crates/mitex-lexer/src/token.rs
@@ -100,7 +100,7 @@ pub enum Token {
     Underscore,
 
     /// A character sequence that doesn't contain any above tokens
-    #[regex(r#"[^\s\\%\{\},\$\[\]\(\)\~/_'";&^#]+"#, priority = 1)]
+    #[regex(r#"[^\s\\%\{\},\$\[\]\(\)\~/_\*'";&^#]+"#, priority = 1)]
     Word,
 
     /// Special dollar signs

--- a/crates/mitex-lexer/src/token.rs
+++ b/crates/mitex-lexer/src/token.rs
@@ -95,12 +95,16 @@ pub enum Token {
     #[token("*")]
     Asterisk,
 
+    /// An ascii atsign
+    #[token("@")]
+    AtSign,
+
     /// An ascii underscore
     #[token("_", priority = 2)]
     Underscore,
 
     /// A character sequence that doesn't contain any above tokens
-    #[regex(r#"[^\s\\%\{\},\$\[\]\(\)\~/_\*'";&^#]+"#, priority = 1)]
+    #[regex(r#"[^\s\\%\{\},\$\[\]\(\)\~/_\*@'";&^#]+"#, priority = 1)]
     Word,
 
     /// Special dollar signs

--- a/crates/mitex-lexer/src/token.rs
+++ b/crates/mitex-lexer/src/token.rs
@@ -91,6 +91,10 @@ pub enum Token {
     #[token("#")]
     Hash,
 
+    /// An ascii asterisk
+    #[token("*")]
+    Asterisk,
+
     /// An ascii underscore
     #[token("_", priority = 2)]
     Underscore,

--- a/crates/mitex-parser/src/parser.rs
+++ b/crates/mitex-parser/src/parser.rs
@@ -379,6 +379,7 @@ impl<'a, S: TokenStream<'a>> Parser<'a, S> {
             | Token::LineComment
             | Token::Hash
             | Token::Asterisk
+            | Token::AtSign
             | Token::Error => {
                 self.eat();
                 return false;

--- a/crates/mitex-parser/src/parser.rs
+++ b/crates/mitex-parser/src/parser.rs
@@ -378,6 +378,7 @@ impl<'a, S: TokenStream<'a>> Parser<'a, S> {
             | Token::Whitespace
             | Token::LineComment
             | Token::Hash
+            | Token::Asterisk
             | Token::Error => {
                 self.eat();
                 return false;

--- a/crates/mitex-parser/src/syntax.rs
+++ b/crates/mitex-parser/src/syntax.rs
@@ -69,6 +69,7 @@ pub enum SyntaxKind {
     TokenEndMath,
     TokenAmpersand,
     TokenHash,
+    TokenAsterisk,
     TokenUnderscore,
     TokenCaret,
     TokenApostrophe,
@@ -126,6 +127,7 @@ impl From<Token> for SyntaxKind {
             Token::Dollar => SyntaxKind::TokenDollar,
             Token::Ampersand => SyntaxKind::TokenAmpersand,
             Token::Hash => SyntaxKind::TokenHash,
+            Token::Asterisk => SyntaxKind::TokenAsterisk,
             Token::NewLine => SyntaxKind::ItemNewLine,
             Token::MacroArg(_) => SyntaxKind::TokenWord,
             Token::CommandName(

--- a/crates/mitex-parser/src/syntax.rs
+++ b/crates/mitex-parser/src/syntax.rs
@@ -70,6 +70,7 @@ pub enum SyntaxKind {
     TokenAmpersand,
     TokenHash,
     TokenAsterisk,
+    TokenAtSign,
     TokenUnderscore,
     TokenCaret,
     TokenApostrophe,
@@ -128,6 +129,7 @@ impl From<Token> for SyntaxKind {
             Token::Ampersand => SyntaxKind::TokenAmpersand,
             Token::Hash => SyntaxKind::TokenHash,
             Token::Asterisk => SyntaxKind::TokenAsterisk,
+            Token::AtSign => SyntaxKind::TokenAtSign,
             Token::NewLine => SyntaxKind::ItemNewLine,
             Token::MacroArg(_) => SyntaxKind::TokenWord,
             Token::CommandName(

--- a/crates/mitex-parser/tests/ast/command.rs
+++ b/crates/mitex-parser/tests/ast/command.rs
@@ -19,7 +19,8 @@ fn test_starrd_command() {
     assert_debug_snapshot!(parse(r#"\varphi*1"#), @r###"
     root
     |cmd(cmd-name("\\varphi"))
-    |text(word'("*1"))
+    |asterisk'("*")
+    |text(word'("1"))
     "###
     );
 }

--- a/crates/mitex-parser/tests/common/mod.rs
+++ b/crates/mitex-parser/tests/common/mod.rs
@@ -74,6 +74,7 @@ pub mod ast_snapshot {
                 SyntaxKind::TokenEndMath => "end-math",
                 SyntaxKind::TokenAmpersand => "ampersand'",
                 SyntaxKind::TokenHash => "hash'",
+                SyntaxKind::TokenAsterisk => "asterisk'",
                 SyntaxKind::TokenUnderscore => "underscore'",
                 SyntaxKind::TokenCaret => "caret'",
                 SyntaxKind::TokenApostrophe => "apostrophe'",

--- a/crates/mitex-parser/tests/common/mod.rs
+++ b/crates/mitex-parser/tests/common/mod.rs
@@ -75,6 +75,7 @@ pub mod ast_snapshot {
                 SyntaxKind::TokenAmpersand => "ampersand'",
                 SyntaxKind::TokenHash => "hash'",
                 SyntaxKind::TokenAsterisk => "asterisk'",
+                SyntaxKind::TokenAtSign => "at-sign'",
                 SyntaxKind::TokenUnderscore => "underscore'",
                 SyntaxKind::TokenCaret => "caret'",
                 SyntaxKind::TokenApostrophe => "apostrophe'",

--- a/crates/mitex/src/lib.rs
+++ b/crates/mitex/src/lib.rs
@@ -334,6 +334,9 @@ impl Converter {
             TokenAsterisk => {
                 f.write_str("\\*")?;
             }
+            TokenAtSign => {
+                f.write_str("\\@")?;
+            }
             TokenDitto => {
                 f.write_str("\\\"")?;
             }
@@ -730,15 +733,6 @@ mod tests {
     }
 
     #[test]
-    fn test_convert_asterisk() {
-        assert_debug_snapshot!(convert_math(r#"$a*b * c$"#), @r###"
-        Ok(
-            "a \\*b  \\* c ",
-        )
-        "###);
-    }
-
-    #[test]
     fn test_convert_greek() {
         assert_debug_snapshot!(convert_math(r#"$\alpha x$"#), @r###"
         Ok(
@@ -906,7 +900,11 @@ mod tests {
         )
         "###
         );
+        assert_debug_snapshot!(convert_math(r#"$a*b * c$"#).unwrap(), @r###""a \\*b  \\* c ""###
+        );
         assert_debug_snapshot!(convert_math(r#"$"$"#).unwrap(), @r###""\\\"""###
+        );
+        assert_debug_snapshot!(convert_text(r#"@abc"#).unwrap(), @r###""\\@abc""###
         );
     }
 

--- a/packages/mitex/examples/example.typ
+++ b/packages/mitex/examples/example.typ
@@ -1,4 +1,4 @@
-#import "@preview/mitex:0.2.2": *
+#import "../lib.typ": *
 
 #set page(width: 500pt, height: auto, margin: 1em)
 
@@ -9,10 +9,7 @@ Write inline equations like #mi("x") or #mi[y].
 Also block equations (this case is from #text(blue.lighten(20%), link("https://katex.org/")[katex.org])):
 
 #mitex(`
-  \newcommand{\f}[2]{#1f(#2)}
-  \f\relax{x} = \int_{-\infty}^\infty
-    \f\hat\xi\,e^{2 \pi i \xi x}
-    \,d\xi
+  abc\text{abfds fds}abc
 `)
 
 We also support text mode (in development):

--- a/packages/mitex/examples/example.typ
+++ b/packages/mitex/examples/example.typ
@@ -9,7 +9,10 @@ Write inline equations like #mi("x") or #mi[y].
 Also block equations (this case is from #text(blue.lighten(20%), link("https://katex.org/")[katex.org])):
 
 #mitex(`
-  abc\text{abfds fds}abc
+  \newcommand{\f}[2]{#1f(#2)}
+  \f\relax{x} = \int_{-\infty}^\infty
+    \f\hat\xi\,e^{2 \pi i \xi x}
+    \,d\xi
 `)
 
 We also support text mode (in development):

--- a/packages/mitex/specs/latex/standard.typ
+++ b/packages/mitex/specs/latex/standard.typ
@@ -32,7 +32,6 @@
 } else {
   texcolor.text
 } 
-#let text-end-space(it) = if it.len() > 1 and it.ends-with(" ") { " " }
 
 // 1. functions created to make it easier to define a spec
 #let operatornamewithlimits(it) = math.op(limits: true, math.upright(it))
@@ -41,7 +40,7 @@
 #let greedy-handle(alias, fn) = define-greedy-cmd(alias, handle: _greedy-handle(fn))
 #let limits-handle(alias, wrap) = define-cmd(1, alias: alias, handle: (it) => math.limits(wrap(it)))
 #let matrix-handle(delim: none, handle: none) = define-env(none, kind: "is-matrix", alias: none, handle: math.mat.with(delim: delim))
-#let text-handle(wrap) = define-cmd(1, handle: it => $wrap(it)$ + text-end-space(it),)
+#let text-handle(handle) = define-cmd(1, handle: handle)
 #let call-or-ignore(fn) = (..args) => if args.pos().len() > 0 { fn(..args) } else { math.zws }
 #let ignore-me = it => {}
 #let ignore-sym = define-sym("")


### PR DESCRIPTION
Related to #46 and #128