### PR TITLE
chore: bump version to 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+
+## 0.2.4
+
+- Fix `\boxed` command.
+- Support basic figure and tabular environments.
+- Add escape symbols for plus, minus and percent.
+- Fix `\left` and `\right`: size of lr use em.
+
+
 ## 0.2.3
 
 - Support nesting math equation like `\text{$x$}`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -342,7 +342,7 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "fuzz-target-mitex"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "afl",
  "divan",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "mitex"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "bitflags",
  "divan",
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "mitex-cli"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -528,11 +528,11 @@ dependencies = [
 
 [[package]]
 name = "mitex-glob"
-version = "0.2.2"
+version = "0.2.4"
 
 [[package]]
 name = "mitex-lexer"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "divan",
  "ecow",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "mitex-parser"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "divan",
  "insta",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "mitex-spec"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "divan",
  "fxhash",
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "mitex-spec-gen"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "mitex-spec",
@@ -585,7 +585,7 @@ dependencies = [
 
 [[package]]
 name = "mitex-wasm"
-version = "0.2.2"
+version = "0.2.4"
 dependencies = [
  "mitex",
  "mitex-spec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "OrangeX4 <orangex4@qq.com>",
     "mgt <mgt@oi-wiki.org>",
 ]
-version = "0.2.2"
+version = "0.2.4"
 edition = "2021"
 readme = "README.md"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ PS: `#set math.equation(numbering: "(1)")` is also valid for MiTeX.
 Following is [a simple example](https://github.com/mitex-rs/mitex/blob/main/packages/mitex/examples/example.typ) of using MiTeX in Typst:
 
 ```typst
-#import "@preview/mitex:0.2.2": *
+#import "@preview/mitex:0.2.4": *
 
 #assert.eq(mitex-convert("\alpha x"), "alpha  x ")
 

--- a/crates/mitex-cli/src/main.rs
+++ b/crates/mitex-cli/src/main.rs
@@ -121,7 +121,7 @@ fn compile(input_path: &str, output_path: &str, is_ast: bool) -> Result<(), Erro
         output_path,
         format!(
             r#"
-#import "@preview/mitex:0.2.2": *
+#import "@preview/mitex:0.2.4": *
 {preludes_str}
 
 {output}"#

--- a/fixtures/underleaf/ieee/main.typ
+++ b/fixtures/underleaf/ieee/main.typ
@@ -1,5 +1,5 @@
 
-#import "@preview/mitex:0.2.2": *
+#import "@preview/mitex:0.2.4": *
 
 #let res = mitex-convert(mode: "text", read("main.tex"))
 #eval(res, mode: "markup", scope: mitex-scope)

--- a/packages/mitex-web/src/main.ts
+++ b/packages/mitex-web/src/main.ts
@@ -58,7 +58,7 @@ const App = () => {
     van.derive(async () => {
       if (fontLoaded.val) {
         svgData.val = await $typst.svg({
-          mainContent: `#import "@preview/mitex:0.2.2": *
+          mainContent: `#import "@preview/mitex:0.2.4": *
         #set page(width: auto, height: auto, margin: 1em);
         #set text(size: 24pt);
         ${darkModeStyle.val}
@@ -128,7 +128,7 @@ const App = () => {
     CopyButton(
       "Copy with template and imports",
       van.derive(
-        () => `#import "@preview/mitex:0.2.2": *\n
+        () => `#import "@preview/mitex:0.2.4": *\n
 #math.equation(eval("$" + \`${output.val}\`.text + "$", mode: "markup", scope: mitex-scope), block: true)`
       )
     ),

--- a/packages/mitex/CHANGELOG.md
+++ b/packages/mitex/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+## 0.2.4
+
+- Fix `\boxed` command.
+- Support basic figure and tabular environments.
+- Add escape symbols for plus, minus and percent.
+- Fix `\left` and `\right`: size of lr use em.
+
+
 ## 0.2.3
 
 - Support nesting math equation like `\text{$x$}`.

--- a/packages/mitex/README.md
+++ b/packages/mitex/README.md
@@ -22,7 +22,7 @@ PS: `#set math.equation(numbering: "(1)")` is also valid for MiTeX.
 Following is [a simple example](https://github.com/mitex-rs/mitex/blob/main/packages/mitex/examples/example.typ) of using MiTeX in Typst:
 
 ```typst
-#import "@preview/mitex:0.2.2": *
+#import "@preview/mitex:0.2.4": *
 
 #assert.eq(mitex-convert("\alpha x"), "alpha  x ")
 

--- a/packages/mitex/typst.toml
+++ b/packages/mitex/typst.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mitex"
-version = "0.2.2"
+version = "0.2.4"
 entrypoint = "lib.typ"
 authors = ["Myriad-Dreamin", "OrangeX4", "Enter-tainer"]
 license = "Apache-2.0"
@@ -8,5 +8,6 @@ description = "LaTeX support for Typst, powered by Rust and WASM."
 
 homepage = "https://github.com/mitex-rs/mitex"
 repository = "https://github.com/mitex-rs/mitex"
+categories = ["utility"]
 keywords = ["wasm", "rust", "LaTeX", "equation"]
 exclude = ["examples"]


### PR DESCRIPTION
## 0.2.4

- Fix `\boxed` command.
- Support basic figure and tabular environments.
- Add escape symbols for plus, minus and percent.
- Fix `\left` and `\right`: size of lr use em.