### PR TITLE
fix: fix “kai is deprecated” warning for Typst v0.14.0

### DIFF
--- a/packages/mitex/specs/latex/standard.typ
+++ b/packages/mitex/specs/latex/standard.typ
@@ -1042,7 +1042,7 @@
   mkern: ignore-sym,
   mathstrut: ignore-sym,
   nonumber: ignore-sym,
-  KaTeX: of-sym(math.upright($kai A T E X$)),
+  KaTeX: of-sym(math.upright($K A T E X$)),
   LaTeX: of-sym(math.upright($L A T E X$)),
   TeX: of-sym(math.upright($T E X$)),
   middle: define-cmd(1, handle: it => math.mid(it)),


### PR DESCRIPTION
```typst
#import "@preview/mitex:0.2.5": mitex
#mitex(`\KaTeX`)
```

Since Typst v0.10.0, the result of the above code has always been wrong.

<img width="180" height="96" alt="图片" src="https://github.com/user-attachments/assets/00e11b5a-1e17-423b-91e4-2f4f0ce2b925" />

But it now has a warning in Typst 0.14.0, affecting all usages, even if `\KaTeX` is not actually used.

```log
    warning: `kai` is deprecated, use ϗ or `\u{3d7}` instead
         ┌─ @preview/mitex:0.2.5\specs\latex\standard.typ:1045:30
         │
    1045 │   KaTeX: of-sym(math.upright($kai A T E X$)),
         │        
```

The line containing `kai` was introduced in #63 on 2023-12-25 from jupyter2typst. I guess it was a typo, because jupyter2typst uses `"KaTeX"`.

Besides, [Logos & Figures - Typst Examples Book](https://sitandr.github.io/typst-examples-book/book/snippets/logos.html#tex-and-latex) has the real `\LaTeX` and `\TeX`, but I think that's out of the scope of this PR.