### PR TITLE
feat: add support for \smash command

### DIFF
--- a/packages/mitex/specs/latex/standard.typ
+++ b/packages/mitex/specs/latex/standard.typ
@@ -114,6 +114,7 @@
   phantom: define-cmd(1, handle: hide),
   hphantom: define-cmd(1, handle: it => box(height: 0pt, hide(it))),
   vphantom: define-cmd(1, handle: it => box(width: 0pt, hide(it))),
+  smash: define-cmd(1, handle: it => box(height: 0pt, align(bottom, $#it$))),
   // Escape symbols
   "_": define-sym("\\_"),
   "^": define-sym("hat"),


### PR DESCRIPTION
# Support `\smash` Command

It was noted in #43 that the `\smash` command is included in the roadmap. But the current version triggers: 
`error: unknown command: \smash.`

this PR provides a basic implementation.

- **Note**: Optional arguments `[t]` and `[b]` are **currently not supported**.
- The command renders the content as a math formula using `$#it$` by default.

## Typst Preview

```typst
#table(
  columns: (1.5fr, 2fr, 2fr),
  inset: 8pt,
  align: horizon + center,
  table.header([Scenario], [Unbalanced], [Smashed]),

  [Square Root],
  [#mi(`$\sqrt{x} + \sqrt{y} + \sqrt{T} + \sqrt{\sum}$`)],
  [#mi(`$\sqrt{\smash{x}} + \sqrt{\smash{y}} + \sqrt{\smash{T}} + \sqrt{\smash{\sum}}$`)],

  [Underline Alignment],
  [#mi(`$\underline{x} + \underline{y} + \underline{a}$`)],
  [#mi(`$\underline{\smash{x}} + \underline{\smash{y}} + \underline{\smash{a}}$`)],

  [Line Height Protection],
  [Text #mi(`$A_{2_2^{2^2}}$`) expands line height],
  [Text #mi(`$A_{\smash{2_2^{2^2}}}$`) maintains line height],

  [Compact Overline],
  [#mi(`$\overline{\frac{1}{2}}$`)],
  [#mi(`$\overline{\smash{\frac{1}{2}}}$`)],

  [Compact Underline],
  [#mi(`$\underline{\frac{1}{2}}$`)],
  [#mi(`$\underline{\smash{\frac{1}{2}}}$`)],
)
```

<img width="2450" height="763" alt="image" src="https://github.com/user-attachments/assets/ffbf7324-e6ce-42fc-bb50-9443d9cee052" />

## LaTeX Preview

<img width="2077" height="945" alt="image" src="https://github.com/user-attachments/assets/6b932428-f28a-48d1-8327-fdce7453f450" />

```latex
\begin{table}[h]
    \centering
    \Large
    \renewcommand{\arraystretch}{1.8}
    \begin{tabularx}{\textwidth}{|>{\centering\arraybackslash}m{5cm}|>{\centering\arraybackslash}X|>{\centering\arraybackslash}X|}
        \hline
        \textbf{Scenario}      & \textbf{Unbalanced}                             & \textbf{Smashed}                                                               \\
        \hline
        Square Root            & $\sqrt{x} + \sqrt{y} + \sqrt{T} + \sqrt{\sum}$  & $\sqrt{\smash{x}} + \sqrt{\smash{y}} + \sqrt{\smash{T}} + \sqrt{\smash{\sum}}$ \\
        \hline
        Underline Alignment    & $\underline{x} + \underline{y} + \underline{a}$ & $\underline{\smash{x}} + \underline{\smash{y}} + \underline{\smash{a}}$        \\
        \hline
        Line Height Protection & Text $A_{2_2^{2^2}}$ expands line height        & Text $A_{\smash{2_2^{2^2}}}$ maintains line height                             \\
        \hline
        Compact Overline       & $\overline{\frac{1}{2}}$                        & $\overline{\smash{\frac{1}{2}}}$                                               \\
        \hline
        Compact Underline      & $\underline{\frac{1}{2}}$                       & $\underline{\smash{\frac{1}{2}}}$                                              \\
        \hline
    \end{tabularx}
\end{table}
```