### PR TITLE
feat: support `\textperthousand` command

### DIFF
--- a/packages/mitex/specs/latex/standard.typ
+++ b/packages/mitex/specs/latex/standard.typ
@@ -940,6 +940,7 @@
   textquoteleft: define-sym("quote.l.single"),
   textquoteright: define-sym("quote.r.single"),
   textregistered: define-sym("®"),
+  textperthousand: define-sym("permille"),
   textsterling: define-sym("pound"),
   textunderscore: define-sym("\\_"),
   thetasym: define-sym("theta.alt"),


### PR DESCRIPTION
fix: #199 

<img width="1336" height="227" alt="image" src="https://github.com/user-attachments/assets/b8c84771-3be4-423b-91b0-dbb3f2b30811" />
